### PR TITLE
Jews and Mongols

### DIFF
--- a/ProjectBalance/events/mongol_events.txt
+++ b/ProjectBalance/events/mongol_events.txt
@@ -907,24 +907,15 @@ narrative_event = {
 	option = {
 		name = "EVTOPTC60001"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60001"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -1772,14 +1763,7 @@ narrative_event = {
 	option = {
 		name = "EVTOPTB60002"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -1793,10 +1777,8 @@ narrative_event = {
 	option = {
 		name = "EVTOPTD60002"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -3440,24 +3422,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -3538,24 +3511,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -3636,24 +3600,15 @@ character_event = {
 	option = {
 		name = "EVTOPTC60010"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -3735,24 +3690,15 @@ character_event = {
 	option = {
 		name = "EVTOPTC60010"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -3833,24 +3779,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_il-khanate }
 		}
 	}
@@ -3935,24 +3872,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -4034,24 +3962,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -4133,24 +4052,15 @@ character_event = {
 	option = {
 		name = "EVTOPTC60010"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -4232,24 +4142,15 @@ character_event = {
 	option = {
 		name = "EVTOPTC60010"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -4328,24 +4229,15 @@ character_event = {
 	option = {
 		name = "EXCELLENT"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
 	option = {
 		name = "EVTOPTD60010"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = e_golden_horde }
 		}
 	}
@@ -4907,7 +4799,7 @@ narrative_event = {
 	desc = "EVTDESC60106"
 	major = yes
 	
-	picture = "GFX_evt_mongols"
+	picture = "GFX_evt_rome_falls"
 	border = "GFX_event_narrative_frame_war"
 	
 	is_triggered_only = yes
@@ -6786,24 +6678,15 @@ narrative_event = {
 	option = {
 		name = "EVTOPTC60201"
 		trigger = {
-			OR = {
-				religion_group = christian
-				AND = {
-					NOT = { religion_group = muslim }
-					NOT = { religion_group = pagan_group }
-					NOT = { religion_group = zoroastrian_group }
-				}
-			}
+			religion_group = christian
 			NOT = { has_landed_title = k_seljuk_turks }
 		}
 	}
 	option = {
 		name = "EVTOPTD60201"
 		trigger = {
-			OR = {
-				religion_group = pagan_group
-				religion_group = zoroastrian_group
-			}
+			NOT = { religion_group = christian }
+			NOT = { religion_group = muslim }
 			NOT = { has_landed_title = k_seljuk_turks }
 		}
 	}


### PR DESCRIPTION
In the current version of PB, there would be bugs if there are Jewish rulers around when the Mongol doomstacks appear (I forgot exactly what but either it'll give them a gazillion troops or give the hordes a gazillion troops if the player is Jewish or something), this was a bug in vanilla 2.0 that was fixed in 2.01. I thus fixed the relevant events.

Also I made sure the Mongols sack Rome event now has the right event picture as in vanilla.
