### PR TITLE
Councillor opinion now affects job performance

### DIFF
--- a/ProjectBalance/events/job_chancellor.txt
+++ b/ProjectBalance/events/job_chancellor.txt
@@ -90,6 +90,19 @@ character_event = {
 			factor = 0.75
 			diplomacy = 18
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -212,6 +225,19 @@ character_event = {
 			factor = 1.25
 			diplomacy = 13
 		}
+		
+		# PB inverse employer opinion factors
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -394,6 +420,19 @@ character_event = {
 			factor = 0.95
 			diplomacy = 20
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -947,6 +986,19 @@ character_event = {
 			factor = 1.25
 			diplomacy = 13
 		}
+		
+		# PB inverse employer opinion factors
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1057,6 +1109,23 @@ letter_event = {
 	
 	option = {
 		name = "EVTOPTA20144"
+		ai_chance = {
+			factor = 10
+			
+			# PB standard employer opinion factors (direct modifier of chance to take the bribe)
+			modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+			modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
+		}
+		
 		wealth = 50
 		FROM = {
 			letter_event = { id = 20145 days = 7 tooltip = "EVTTOOLTIP20145" }
@@ -1071,6 +1140,7 @@ letter_event = {
 	}
 	option = {
 		name = "EVTOPTB20144"
+		ai_chance = { factor = 10 }
 		prestige = 5
 		FROM = { letter_event = { id = 20146 days = 7 tooltip = "EVTTOOLTIP20146" } }
 	}
@@ -1189,6 +1259,19 @@ character_event = {
 			factor = 0.75
 			diplomacy = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {

--- a/ProjectBalance/events/job_lord_spiritual.txt
+++ b/ProjectBalance/events/job_lord_spiritual.txt
@@ -195,6 +195,19 @@ character_event = {
 			location = { religion_group = muslim }
 			religion_group = muslim
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 
 	option = {
@@ -359,6 +372,19 @@ character_event = {
 			religion_group = pagan_group
 			is_reformed_religion = no
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1028,6 +1054,19 @@ character_event = {
 			factor = 2.0
 			religion_authority = 0.8
 		}
+		
+		# PB inverse employer opinion factors
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 
 	option = {
@@ -1227,6 +1266,19 @@ character_event = {
 			factor = 0.75
 			religion_authority = 0.8
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1315,6 +1367,19 @@ character_event = {
 			factor = 0.75
 			religion_authority = 0.8
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1508,6 +1573,19 @@ character_event = {
 			factor = 0.75
 			religion_authority = 0.8
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1630,6 +1708,19 @@ character_event = {
 			factor = 0.75
 			learning = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1752,6 +1843,19 @@ character_event = {
 			factor = 0.75
 			learning = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -1851,11 +1955,28 @@ character_event = {
 			factor = 0.75
 			learning = 13
 		}
+		
+		# NOTE: no PB employer opinion factors for heretic MTTH, only for AI chance to become one once the event's already triggered.
 	}
 	
 	option = {
 		name = "EVTOPTA927"
-		ai_chance = { factor = 80 }
+		ai_chance = {
+			factor = 80
+			
+			# PB standard employer opinion factors (would be inverse set but is an ai_chance, not an MTTH)
+			modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+			modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+			modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+			modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
+		}
 		become_heretic = yes
 		hidden_tooltip = {
 			liege = { letter_event = { id = 20270 days = 2 } }
@@ -1878,7 +1999,7 @@ letter_event = {
 	option = {
 		name = "EVTOPTA20270"
 		ai_chance = { factor = 100 }
-		FROM = { imprison = yes }
+		FROM = { imprison = yes } # chaplains who hate their lieges are, in this case, more likely to end up in prison and consequently hate the liege forever
 	}
 	option = {
 		name = "EVTOPTB20270"
@@ -1964,6 +2085,19 @@ character_event = {
 			factor = 0.75
 			religion_authority = 0.8
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -2210,6 +2344,19 @@ character_event = {
 			factor = 0.75
 			trait = envious
 		}
+
+		# PB inverse employer opinion factors
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -2298,6 +2445,19 @@ character_event = {
 			factor = 0.75
 			learning = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {

--- a/ProjectBalance/events/job_marshal.txt
+++ b/ProjectBalance/events/job_marshal.txt
@@ -210,6 +210,19 @@ character_event = {
 			factor = 0.75
 			martial = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -374,6 +387,19 @@ character_event = {
 			factor = 0.75
 			martial = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -471,6 +497,19 @@ character_event = {
 			factor = 1.25
 			martial = 13
 		}
+		
+		# PB inverse employer opinion factors (likelihood effect from degree of devotion to liege)
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {

--- a/ProjectBalance/events/job_spymaster.txt
+++ b/ProjectBalance/events/job_spymaster.txt
@@ -86,6 +86,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -516,6 +529,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 16
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	immediate = {
@@ -1248,6 +1274,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 16
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	immediate = {
@@ -1765,6 +1804,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 
 	option = {
@@ -2020,6 +2072,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -2614,6 +2679,19 @@ character_event = {
 			factor = 0.75
 			intrigue = 13
 		}
+
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {

--- a/ProjectBalance/events/job_steward.txt
+++ b/ProjectBalance/events/job_steward.txt
@@ -77,6 +77,19 @@ character_event = {
 			factor = 0.75
 			stewardship = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {
@@ -371,6 +384,19 @@ character_event = {
 				NOT = { religion = ROOT }
 			}
 		}
+
+		# PB inverse employer opinion factors (steward not invested in his work)
+		modifier = { factor = 0.91  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 0.94  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 0.97  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  35 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  55 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  75 } }
+		modifier = { factor = 1.04          opinion = { who = liege value =  95 } }
 	}
 
 	option = {
@@ -513,6 +539,19 @@ character_event = {
 			factor = 0.75
 			stewardship = 13
 		}
+		
+		# PB standard employer opinion factors
+		modifier = { factor = 1.09  not = { opinion = { who = liege value = -99 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -80 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -60 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -40 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value = -20 } } }
+		modifier = { factor = 1.06  not = { opinion = { who = liege value =   0 } } }
+		modifier = { factor = 1.03  not = { opinion = { who = liege value =  20 } } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  35 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  55 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  75 } }
+		modifier = { factor = 0.96          opinion = { who = liege value =  95 } }
 	}
 	
 	option = {


### PR DESCRIPTION
All job action events wherein councillor opinion of employer would play
a role in their MTTH or associated AI chance factors have been modified
to account for either the "PB standard employer opinion factors" modifier set
(lower factors are better) or the "PB inverse employer opinion factors"
modifier set (higher factors are better).  The factor curve behind these two
modifier sets can be easily adjusted in the future.  Details and rationale
for the present curve can be found in this Project Balance forum post:

http://forum.paradoxplaza.com/forum/showthread.php?594436-Project-Balance&p=16628830&viewfull=1#post16628830

Now, it pays to reward your councillors and maintain your relationships
with them.  Concept based upon the principle that councillors which
dislike their employer will perform worse at their jobs, sometimes out
of spite and sometimes out of lack of investment, and in contrast,
councillors that are very satisfied with their job and their liege will
perform slightly better than others of equal skill.

Note that the current curve provides no modifier bonus until reaching 35+
opinion and is heavily skewed toward punishing bad relations, not boosting
councillor performance.  All in all, the effects of the employer opinion
modifier sets will only be dramatic at significantly negative relations. Again,
see the forum post for the actual composite curve that's included in this
commit.
