### PR TITLE
Fix for AI handicap for councillor opinion bonus

### DIFF
--- a/ProjectBalance/events/job_chancellor.txt
+++ b/ProjectBalance/events/job_chancellor.txt
@@ -123,7 +123,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -292,7 +292,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        
@@ -521,7 +521,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1121,7 +1121,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        
@@ -1280,7 +1280,7 @@ letter_event = {
 			modifier = {
 				factor = 0.96        
 				opinion = { who = liege value = 35 }
-				ai = yes
+				liege = { ai = yes }
 			}
 			modifier = {
 				factor = 0.96        
@@ -1462,7 +1462,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        

--- a/ProjectBalance/events/job_lord_spiritual.txt
+++ b/ProjectBalance/events/job_lord_spiritual.txt
@@ -228,7 +228,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -439,7 +439,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1155,7 +1155,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        
@@ -1401,7 +1401,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1536,7 +1536,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1776,7 +1776,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1945,7 +1945,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -2114,7 +2114,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -2268,7 +2268,7 @@ character_event = {
 			modifier = {
 				factor = 0.96        
 				opinion = { who = liege value = 35 }
-				ai = yes
+				liege = { ai = yes }
 			}
 			modifier = {
 				factor = 0.96        
@@ -2424,7 +2424,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -2717,7 +2717,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        
@@ -2852,7 +2852,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        

--- a/ProjectBalance/events/job_marshal.txt
+++ b/ProjectBalance/events/job_marshal.txt
@@ -243,7 +243,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -454,7 +454,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -598,7 +598,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        

--- a/ProjectBalance/events/job_spymaster.txt
+++ b/ProjectBalance/events/job_spymaster.txt
@@ -119,7 +119,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -596,7 +596,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1375,7 +1375,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -1939,7 +1939,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -2241,7 +2241,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -2882,7 +2882,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        

--- a/ProjectBalance/events/job_steward.txt
+++ b/ProjectBalance/events/job_steward.txt
@@ -110,7 +110,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        
@@ -451,7 +451,7 @@ character_event = {
 		modifier = {
 			factor = 1.04        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 1.04        
@@ -640,7 +640,7 @@ character_event = {
 		modifier = {
 			factor = 0.96        
 			opinion = { who = liege value = 35 }
-			ai = yes
+			liege = { ai = yes }
 		}
 		modifier = {
 			factor = 0.96        


### PR DESCRIPTION
AI _lieges_ get access to the 1st tier of councillor opinion bonus, not
AI _councillors_.
