### PR TITLE
Combat traits in Ruler Designer + minor additions

### DIFF
--- a/ProjectBalance/ChangeLog.txt
+++ b/ProjectBalance/ChangeLog.txt
@@ -1,3 +1,6 @@
+3.4.1
+	Combat/fighter traits (for the duel engine) are again customizable in the Ruler Designer [zijistark]
+
 3.4.0
 	Added a new faction system. All crown authority factions have been merged into a single faction that is more responsive to the actions of their liege, and have more actions they can take. Every 3 to 7 years they hold a meeting to determine what action they'll take. If they're in a bad mood they might issue an ultimatum to their liege, but if treated well they will not be much of a threat. They're potentially a much greater threat than the old factions however, as the faction is global to the realm rather than specific to a single dejure kingdom or empire
 	Fixed a few minor event bugs

--- a/ProjectBalance/common/traits/combat_traits.txt
+++ b/ProjectBalance/common/traits/combat_traits.txt
@@ -7,7 +7,7 @@ poor_warrior = {
 		skilled_warrior
 		master_warrior
 	}
-	customizer = no
+	customizer = yes
 	random = no
 }
 
@@ -19,7 +19,7 @@ trained_warrior = {
 		skilled_warrior
 		master_warrior
 	}
-	customizer = no
+	customizer = yes
 	random = no
 }
 
@@ -34,7 +34,7 @@ skilled_warrior = {
 		trained_warrior
 		master_warrior
 	}
-	customizer = no
+	customizer = yes
 	random = no
 }
 
@@ -49,6 +49,6 @@ master_warrior = {
 		trained_warrior
 		skilled_warrior
 	}
-	customizer = no
+	customizer = yes
 	random = no
 }

--- a/ProjectBalance/events/PB_startup_2.txt
+++ b/ProjectBalance/events/PB_startup_2.txt
@@ -20,6 +20,14 @@ narrative_event = {
 	
 	immediate = {
 		any_playable_ruler = {
+			limit = {
+				NOT = { # only assign a combat trait to characters that don't already have one
+					trait = poor_warrior
+					trait = trained_warrior
+					trait = skilled_warrior
+					trait = master_warrior
+				}
+			}
 			set_variable = { which = "combat_skill" value = 0 }
 			if = {
 				limit = { trait = misguided_warrior }
@@ -58,6 +66,10 @@ narrative_event = {
 				change_variable = { which = "combat_skill" value = 2 }
 			}
 			if = {
+				limit = { trait = agile }
+				change_variable = { which = "combat_skill" value = 1 }
+			}
+			if = {
 				limit = { trait = weak }
 				change_variable = { which = "combat_skill" value = -2 }
 			}
@@ -72,6 +84,10 @@ narrative_event = {
 			if = {
 				limit = { trait = inbred }
 				change_variable = { which = "combat_skill" value = -2 }
+			}
+			if = {
+				limit = { trait = clubfooted }
+				change_variable = { which = "combat_skill" value = -1 }
 			}
 			if = {
 				limit = { trait = slothful }
@@ -111,6 +127,7 @@ narrative_event = {
 				}
 				add_trait = poor_warrior
 			}
+			set_variable = { which = "combat_skill" value = 0 } # free memory (per character)
 		}
 		if = {
 			limit = { year = 1066 }


### PR DESCRIPTION
Combat traits can now again be customized in the Ruler Designer.  The
startup trait distribution event has been modified to respect a
customized (or otherwise already assigned) combat trait as well as to
take into account the agile and clubfooted traits, and the per-character
combat_skill variable is freed after use.
