### PR TITLE
Loans++

### DIFF
--- a/ProjectBalance/ChangeLog.txt
+++ b/ProjectBalance/ChangeLog.txt
@@ -1,6 +1,8 @@
 3.4.1
 	Updated the implementation of the New Duel Engine to its latest version
 	Combat/fighter traits (for the duel engine) are again customizable in the Ruler Designer [zijistark]
+	Added combat trait advancement (CTA) system for adult rulers under 50 (and their marshals). Earn experience points toward trait level-up via personal participation in battles and all types of victorious duels. Dramatically decrease the time taken to advance by applying yourself toward the new, associated set of ambitions. Age, skill tier, and traits will also impact your rate of progress. You may only advance 1 level beyond that with which you reach adulthood. In the exceptional case that you start with no combat education whatsoever, then you are allowed to advance up to 2 levels. [zijistark]
+	Swanky ambition icon for CTA (credit goes to AnaxXiphos)
 	The starting trade posts are now built by event rather than using the history files, simplifying maintenance of PB, and reducing the chance of bugs
 	Fixed the Autonomy faction being able to demand a county be given away when their liege was under, rather than over, the demesne limit
 	(PB+SWMH) Tweaks to culture/religion in the Caucasus
@@ -8,8 +10,10 @@
 	Merged the loans from Jewish bankers with PB's system. Main difference is that expelling Jews now frees one from PB's loans, and that loans are inherited by one's heir. The AI will now also take loans if bankrupt
 	Stewardship now reduces the interest charged on loans by 1% per 5 stewardship, capping out at a 3% reduction (7% interest rate)
 	It is now possible to repay half a loan (except 100g loans) if the size of loan below it is available. E.G., if you've got a 400g loan but no 200g loan you can repay 200g of the 400g loan
+	AI loan-taking and loan-repayment are now much more prompt, esp. when at war (inversely so for repayment during war) [zijistark]
+	Jewish rulers may now also take loans, although they cannot escape their debts by simply "Expelling the Jewry" [zijistark]
+	Closed some borrowing loopholes that would allow holy orders, mercenary bands, claimant adventurers, rebels, etc. to take loans from Jewish merchants [zijistark]
 	Portage across the Suez now takes approximately six weeks rather than one
-	Added combat/fighter trait advancement system for adults under 50. Select ambition(s) to advance your trait (optional), earn points toward trait level-up via personal participation in battles and all types of victorious duels. Age, skill tier, and traits will impact your rate of progress. You may only advance 1 level beyond that with which you reach adulthood except when starting adulthood with no combat education at all, in which case you are allowed to advance up to 2 levels. [zijistark]
 	The claimant faction can no longer be started if the claimant is theocratic and the target title is not
 
 3.4.0

--- a/ProjectBalance/decisions/PB_loans.txt
+++ b/ProjectBalance/decisions/PB_loans.txt
@@ -43,17 +43,38 @@ decisions = {
 			}
 			clr_character_flag = loan_decisions_temp
 		}
+		ai_will_do = {
+			factor = 0
+		}
 	}
 	#Small loan - 100
 	take_small_loan = {
 		potential = {
+			is_ruler = yes
 			prisoner = no
+			primary_title = {
+				OR = {
+					# no popes/patriarchs: other rel. heads OK
+					is_landless_type_title = no
+					is_tribal_type_title = yes
+				}
+				NOT = {
+					temporary = yes # claimant adventurers
+					holy_order = yes
+					mercenary = yes
+					rebel = yes
+				}
+			}
 			NOT = { has_character_modifier = small_loan }
-			has_character_flag = loan_decisions
+			OR = {
+				has_character_flag = loan_decisions
+				ai = yes
+			}
 			OR = {
 				religion_group = christian
 				religion_group = muslim
 				religion_group = zoroastrian_group
+				religion_group = jewish_group
 			}
 		}
 		allow = {
@@ -78,20 +99,43 @@ decisions = {
 				wealth = 0
 			}
 			modifier = {
-				factor = 0.01 # Slow it down
+				factor = 10 # if at war personally, loan option is forced to AI attention ca. 10x/year
+				war = yes
+			}
+			modifier = {
+				factor = 0  # 75% monthly chance randomizer that AI will take loan if it's in the red
+				random = 75 # in any given month (and would otherwise take it). slight slow-down.
 			}
 		}
 	}
 	#Medium loan - 200
 	take_medium_loan = {
 		potential = {
+			is_ruler = yes
 			prisoner = no
+			primary_title = {
+				OR = {
+					# no popes/patriarchs: other rel. heads OK
+					is_landless_type_title = no
+					is_tribal_type_title = yes
+				}
+				NOT = {
+					temporary = yes # claimant adventurers
+					holy_order = yes
+					mercenary = yes
+					rebel = yes
+				}
+			}
 			NOT = { has_character_modifier = medium_loan }
-			has_character_flag = loan_decisions
+			OR = {
+				has_character_flag = loan_decisions
+				ai = yes
+			}
 			OR = {
 				religion_group = christian
 				religion_group = muslim
 				religion_group = zoroastrian_group
+				religion_group = jewish_group
 			}
 		}
 		allow = {
@@ -124,20 +168,43 @@ decisions = {
 				NOT = { has_character_modifier = small_loan }
 			}
 			modifier = {
-				factor = 0.01 # Slow it down
+				factor = 10 # if at war personally, loan option is forced to AI attention ca. 10x/year
+				war = yes
+			}
+			modifier = {
+				factor = 0  # 75% monthly chance randomizer that AI will take loan if it's in the red
+				random = 75 # in any given month (and would otherwise take it). slight slow-down.
 			}
 		}
 	}
 	#Large loan - 400
 	take_large_loan = {
 		potential = {
+			is_ruler = yes
 			prisoner = no
+			primary_title = {
+				OR = {
+					# no popes/patriarchs: other rel. heads OK
+					is_landless_type_title = no
+					is_tribal_type_title = yes
+				}
+				NOT = {
+					temporary = yes # claimant adventurers
+					holy_order = yes
+					mercenary = yes
+					rebel = yes
+				}
+			}
 			NOT = { has_character_modifier = large_loan }
-			has_character_flag = loan_decisions
+			OR = {
+				has_character_flag = loan_decisions
+				ai = yes
+			}
 			OR = {
 				religion_group = christian
 				religion_group = muslim
 				religion_group = zoroastrian_group
+				religion_group = jewish_group
 			}
 		}
 		allow = {
@@ -174,20 +241,43 @@ decisions = {
 				NOT = { has_character_modifier = medium_loan }
 			}
 			modifier = {
-				factor = 0.01 # Slow it down
+				factor = 10 # if at war personally, loan option is forced to AI attention ca. 10x/year
+				war = yes
+			}
+			modifier = {
+				factor = 0  # 75% monthly chance randomizer that AI will take loan if it's in the red
+				random = 75 # in any given month (and would otherwise take it). slight slow-down.
 			}
 		}
 	}
 	#Huge loan - 800
 	take_huge_loan = {
 		potential = {
+			is_ruler = yes
 			prisoner = no
+			primary_title = {
+				OR = {
+					# no popes/patriarchs: other rel. heads OK
+					is_landless_type_title = no
+					is_tribal_type_title = yes
+				}
+				NOT = {
+					temporary = yes # claimant adventurers
+					holy_order = yes
+					mercenary = yes
+					rebel = yes
+				}
+			}
 			NOT = { has_character_modifier = huge_loan }
-			has_character_flag = loan_decisions
+			OR = {
+				has_character_flag = loan_decisions
+				ai = yes
+			}
 			OR = {
 				religion_group = christian
 				religion_group = muslim
 				religion_group = zoroastrian_group
+				religion_group = jewish_group
 			}
 		}
 		allow = {
@@ -225,7 +315,12 @@ decisions = {
 				NOT = { has_character_modifier = large_loan }
 			}
 			modifier = {
-				factor = 0.01 # Slow it down
+				factor = 10 # if at war personally, loan option is forced to AI attention ca. 10x/year
+				war = yes
+			}
+			modifier = {
+				factor = 0  # 75% monthly chance randomizer that AI will take loan if it's in the red
+				random = 75 # in any given month (and would otherwise take it). slight slow-down.
 			}
 		}
 	}
@@ -291,7 +386,11 @@ decisions = {
 				NOT = { wealth = 150 }
 			}
 			modifier = {
-				factor = 0.1 # Slow it down
+				factor = 0.5 # slow it down, ca. once every 2 years
+			}
+			modifier = {
+				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
+				war = yes
 			}
 		}
 	}
@@ -301,7 +400,7 @@ decisions = {
 			has_character_modifier = medium_loan
 		}
 		allow = {
-			wealth = 200
+			wealth = 220
 		}
 		effect = {
 			if = {
@@ -354,7 +453,11 @@ decisions = {
 				NOT = { wealth = 300 }
 			}
 			modifier = {
-				factor = 0.1 # Slow it down
+				factor = 0.5 # slow it down, ca. once every 2 years
+			}
+			modifier = {
+				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
+				war = yes
 			}
 		}
 	}
@@ -417,7 +520,11 @@ decisions = {
 				NOT = { wealth = 550 }
 			}
 			modifier = {
-				factor = 0.1 # Slow it down
+				factor = 0.5 # slow it down, ca. once every 2 years
+			}
+			modifier = {
+				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
+				war = yes
 			}
 		}
 	}
@@ -461,7 +568,11 @@ decisions = {
 				NOT = { wealth = 1000 }
 			}
 			modifier = {
-				factor = 0.1 # Slow it down
+				factor = 0.5 # slow it down, ca. once every 2 years
+			}
+			modifier = {
+				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
+				war = yes
 			}
 		}
 	}

--- a/ProjectBalance/decisions/PB_loans.txt
+++ b/ProjectBalance/decisions/PB_loans.txt
@@ -91,6 +91,11 @@ decisions = {
 				inherit = yes
 			}
 			wealth = 100
+			
+			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan1_take_count value = 1 }
+			}
 		}
 		ai_will_do = {
 			factor = 1
@@ -156,6 +161,11 @@ decisions = {
 				inherit = yes
 			}
 			wealth = 200
+			
+			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan2_take_count value = 1 }
+			}
 		}
 		ai_will_do = {
 			factor = 1
@@ -225,6 +235,11 @@ decisions = {
 				inherit = yes
 			}
 			wealth = 400
+			
+			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan3_take_count value = 1 }
+			}
 		}
 		ai_will_do = {
 			factor = 1
@@ -295,6 +310,11 @@ decisions = {
 				inherit = yes
 			}
 			wealth = 800
+			
+			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan4_take_count value = 1 }
+			}
 		}
 		ai_will_do = {
 			factor = 1
@@ -337,9 +357,19 @@ decisions = {
 		}
 		effect = {
 			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan1_pmt_count value = 1 }
+			}
+			
+			if = {
 				limit = { has_character_modifier = small_loan }
 				set_character_flag = temp_loan
 				remove_character_modifier = small_loan
+				
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan1_paid_count value = 1 }
+				}
 			}
 			if = {
 				limit = {
@@ -352,6 +382,12 @@ decisions = {
 					name = small_loan
 					duration = -1
 					inherit = yes
+				}
+				
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan2_paid_count value = 1 }
+					change_variable = { which = loan1_take_count value = 1 }
 				}
 			}
 			clr_character_flag = temp_loan
@@ -390,23 +426,41 @@ decisions = {
 			}
 			modifier = {
 				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
-				war = yes
+				OR = {
+					war = yes
+					any_liege = {
+						war = yes
+						has_raised_levies = ROOT
+					}
+				}
 			}
 		}
 	}
 	#Repay medium loan - 200
 	repay_medium_loan = {
 		potential = {
-			has_character_modifier = medium_loan
+			OR = {
+				has_character_modifier = medium_loan
+				has_character_modifier = large_loan
+			}
 		}
 		allow = {
 			wealth = 220
 		}
 		effect = {
 			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan2_pmt_count value = 1 }
+			}
+			if = {
 				limit = { has_character_modifier = medium_loan }
 				set_character_flag = temp_loan
 				remove_character_modifier = medium_loan
+
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan2_paid_count value = 1 }
+				}
 			}
 			if = {
 				limit = {
@@ -419,6 +473,12 @@ decisions = {
 					name = medium_loan
 					duration = -1
 					inherit = yes
+				}
+				
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan3_paid_count value = 1 }
+					change_variable = { which = loan2_take_count value = 1 }
 				}
 			}
 			clr_character_flag = temp_loan
@@ -457,23 +517,42 @@ decisions = {
 			}
 			modifier = {
 				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
-				war = yes
+				OR = {
+					war = yes
+					any_liege = {
+						war = yes
+						has_raised_levies = ROOT
+					}
+				}
 			}
 		}
 	}
 	#Repay large loan - 400
 	repay_large_loan = {
 		potential = {
-			has_character_modifier = large_loan
+			OR = {
+				has_character_modifier = large_loan
+				has_character_modifier = huge_loan
+			}
 		}
 		allow = {
 			wealth = 440
 		}
 		effect = {
 			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan3_pmt_count value = 1 }
+			}
+			
+			if = {
 				limit = { has_character_modifier = large_loan }
 				set_character_flag = temp_loan
 				remove_character_modifier = large_loan
+				
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan3_paid_count value = 1 }
+				}
 			}
 			if = {
 				limit = {
@@ -486,6 +565,12 @@ decisions = {
 					name = large_loan
 					duration = -1
 					inherit = yes
+				}
+
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan4_paid_count value = 1 }
+					change_variable = { which = loan3_take_count value = 1 }
 				}
 			}
 			clr_character_flag = temp_loan
@@ -524,7 +609,13 @@ decisions = {
 			}
 			modifier = {
 				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
-				war = yes
+				OR = {
+					war = yes
+					any_liege = {
+						war = yes
+						has_raised_levies = ROOT
+					}
+				}
 			}
 		}
 	}
@@ -537,7 +628,14 @@ decisions = {
 			wealth = 880
 		}
 		effect = {
+			if = {
+				limit = { has_global_flag = debug_loans }
+				change_variable = { which = loan4_pmt_count value = 1 }
+				change_variable = { which = loan4_paid_count value = 1 }
+			}
+			
 			remove_character_modifier = huge_loan
+				
 			if = {
 				limit = { NOT = { stewardship = 5 } }
 				wealth = -80
@@ -572,7 +670,13 @@ decisions = {
 			}
 			modifier = {
 				factor = 0.2 # slow it to a crawl during war, ca. once every 10 years
-				war = yes
+				OR = {
+					war = yes
+					any_liege = {
+						war = yes
+						has_raised_levies = ROOT
+					}
+				}
 			}
 		}
 	}

--- a/ProjectBalance/decisions/realm_decisions.txt
+++ b/ProjectBalance/decisions/realm_decisions.txt
@@ -1082,18 +1082,34 @@ decisions = {
 			if = {
 				limit = { has_character_modifier = small_loan }
 				remove_character_modifier = small_loan
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan1_expel_count value = 1 }
+				}
 			}
 			if = {
 				limit = { has_character_modifier = medium_loan }
 				remove_character_modifier = medium_loan
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan2_expel_count value = 1 }
+				}
 			}
 			if = {
 				limit = { has_character_modifier = large_loan }
 				remove_character_modifier = large_loan
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan3_expel_count value = 1 }
+				}
 			}
 			if = {
 				limit = { has_character_modifier = huge_loan }
 				remove_character_modifier = huge_loan
+				if = {
+					limit = { has_global_flag = debug_loans }
+					change_variable = { which = loan4_expel_count value = 1 }
+				}
 			}
 			add_character_modifier = {
 				name = expelled_jewish
@@ -1104,11 +1120,11 @@ decisions = {
 				text = jews_are_expelled
 			}
 			hidden_tooltip = {
-				character_event = { id = SoA.105 }
-				add_character_modifier = {
-					name = expelled_jews_timer
-					duration = 7300
-					hidden = yes
+				character_event = { id = SoA.105 } # in theory, this would now default all loans in the realm.
+				add_character_modifier = {         # however, it is probably best left as it is.  the jewish
+					name = expelled_jews_timer     # merchants can just keep collecting yearly interest on
+					duration = 7300                # the rest of the realm via the Jewish Underground Mafia
+					hidden = yes                   # or something similarly persuasive.
 				}
 			}
 		}

--- a/ProjectBalance/events/PB_various.txt
+++ b/ProjectBalance/events/PB_various.txt
@@ -148,9 +148,104 @@ character_event = {
 			has_character_modifier = huge_loan
 		}
 	}
+	
 	#Pay interest
 	option = {
 		name = meneth.203.a
+		ai_chance = {
+			factor = 10 # AI will prefer piecemeal, since the event is yearly and the AI will also
+						# be considering repayment in full via decision fairly regularly. if they have
+						# no wars going on and 40% of their yearly income in reserves and enough cash
+						# to do at least a half-payment (if possible) or otherwise a full and retain a
+						# slight buffer, then the scales will tip significantly toward repayment of
+						# whatever they can, however.
+			
+			modifier = {
+				factor = 10 # AI should pay piecemeal if they don't have enough reserves for 3 months of
+				            # expenses, assuming a worst-case operating net income near zero (maybe would
+							# stretch 6 months if operating quite profitably)
+				NOT = { scaled_wealth = 0.25 }
+			}
+			modifier = {
+				factor = 2
+				scaled_wealth = 0.25
+				NOT = { scaled_wealth = 0.4 } # after 40%, we don't really care compared to other factors.
+			}
+			modifier = {
+				factor = 10 # a demesne war combined with a liege's war having raised our levies, and we
+				war = yes   # are essentially guaranteed to go with the piecemeal payment option.
+			}
+			modifier = {
+				factor = 5
+				# approx. half the maintenance will need to be paid if our liege levy is raised, relative
+				# to funding our own demesne war. same for relative importance of not running out of funds.
+				
+				any_liege = {
+					war = yes
+					has_raised_levies = ROOT
+				}
+			}
+			
+			# can we pay the maximum possible at this time and get away relatively unscathed?
+			modifier = {
+				factor = 0.2 # counteracts our levies being raised (half a personal war, half a severe
+				             # short-term savings deficit-- significantly exceeds all other factors)
+				OR = {
+					AND = {
+						wealth = 150 # buffer above max. cost of half-paid (same minimums as decisions)
+						OR = {
+							has_character_modifier = small_loan
+							AND = {
+								NOT = { has_character_modifier = small_loan } # poorman's XOR at work
+								has_character_modifier = medium_loan
+							}
+						}
+					}
+					AND = {
+						wealth = 300
+						OR = {
+							has_character_modifier = medium_loan
+							AND = {
+								NOT = { has_character_modifier = medium_loan }
+								has_character_modifier = large_loan
+							}
+						}
+					}
+					AND = {
+						wealth = 550
+						OR = {
+							has_character_modifier = large_loan
+							AND = {
+								NOT = { has_character_modifier = large_loan }
+								has_character_modifier = huge_loan
+							}
+						}
+					}
+					AND = {
+						wealth = 1000
+						has_character_modifier = huge_loan
+					}
+				}
+			}
+			
+			# the more our reserves in terms of our time horizon's operating costs (which must include
+			# investments like holding upgrades, though scaled_wealth doesn't), the more likely we are
+			# to prefer to pay as much as possible to minimize future interest (and other loan maluses),
+			# ceteris paribus.
+			modifier = {
+				factor = 0.75
+				scaled_wealth = 1.25
+			}
+			modifier = {
+				factor = 0.75
+				scaled_wealth = 2.5
+			}
+			modifier = {
+				factor = 0.75
+				scaled_wealth = 3.75
+			}
+		}
+		
 		custom_tooltip = {
 			text = pay_interest
 			hidden_tooltip = {
@@ -178,6 +273,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -7
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan1_pmt_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -204,6 +304,11 @@ character_event = {
 					if = {
 						limit = { stewardship = 15 }
 						wealth = -14
+					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan2_pmt_count value = 1 }
 					}
 				}
 				if = {
@@ -232,6 +337,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -28
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan3_pmt_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -259,6 +369,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -56
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan4_pmt_count value = 1 }
+					}
 				}
 			}
 		}
@@ -267,11 +382,18 @@ character_event = {
 	option = {
 		name = meneth.203.b
 		trigger = {
-			wealth = 110
+			wealth = 110 # TODO: needs to be revised to actually cover the
+			             # minimum based upon what loan tiers have been taken.
+						 # otherwise, the char might get to skip yearly interest
+						 # (a relatively rare chance for the AI, though).
 		}
+		ai_chance = {
+			factor = 10
+		}
+		
 		custom_tooltip = {
 			text = repay_loans
-			hidden_tooltip = {
+			hidden_tooltip = {		
 				if = {
 					limit = { has_character_modifier = small_loan }
 					if = {
@@ -296,6 +418,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -7
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan1_pmt_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -322,6 +449,11 @@ character_event = {
 					if = {
 						limit = { stewardship = 15 }
 						wealth = -14
+					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan2_pmt_count value = 1 }
 					}
 				}
 				if = {
@@ -350,6 +482,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -28
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan3_pmt_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -377,6 +514,11 @@ character_event = {
 						limit = { stewardship = 15 }
 						wealth = -56
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan4_pmt_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -385,6 +527,11 @@ character_event = {
 					}
 					wealth = -800
 					remove_character_modifier = huge_loan
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan4_paid_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -399,6 +546,14 @@ character_event = {
 						duration = -1
 						inherit = yes
 					}
+										
+					# basic debt consolidation. beautiful.
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan4_paid_count value = 1 }
+						change_variable = { which = loan3_take_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -407,6 +562,11 @@ character_event = {
 					}
 					wealth = -400
 					remove_character_modifier = large_loan
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan3_paid_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -421,6 +581,12 @@ character_event = {
 						duration = -1
 						inherit = yes
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan3_paid_count value = 1 }
+						change_variable = { which = loan2_take_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -429,6 +595,11 @@ character_event = {
 					}
 					wealth = -200
 					remove_character_modifier = medium_loan
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan2_paid_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -443,6 +614,12 @@ character_event = {
 						duration = -1
 						inherit = yes
 					}
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan2_paid_count value = 1 }
+						change_variable = { which = loan1_take_count value = 1 }
+					}
 				}
 				if = {
 					limit = {
@@ -451,6 +628,11 @@ character_event = {
 					}
 					wealth = -100
 					remove_character_modifier = small_loan
+					
+					if = {
+						limit = { has_global_flag = debug_loans }
+						change_variable = { which = loan1_paid_count value = 1 }
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- A number of fixes applied to the recent loans changes
- AI is ready to actually use loans, intelligently and aggressively borrowing when funds are exhausted, repaying as promptly as possible, and just maintaining minimum payments when it's expedient.  Both the decisions and the annual event have been outfitted appropriately
- Optional tracing support for observing long-term aggregate AI debt management behavior (do they promptly pay their debts off, do they get into a downward spiral of debt racking-up, how much are they in debt in time-series, how much interest is paid over an average ruler's lifetime, etc.) instrumented throughout the loans code
- Took care of some oversights that would've allowed some silly and abusive things now that the AI is allowed to take loan decisions
- Opened up loan-taking to Jewish characters.  There is no flavor or historical or gameplay reason to disallow Jewish characters from borrowing from Jewish merchants.  They just can't expel the Jews to get out of their debts.
