### PR TITLE
Crown authority law revocation cooldown

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -3,13 +3,18 @@
 	(PB+SWMH) Fixed three provinces in Ethiopia having no holdings
 	Reduced PB's across the board fertility penalty to 5% (from 10%)
 	(PB+SWMH+NBRT+) Fixed an issue where movement involving a few specific provinces would take months rather than days
-	Fixed mismatched localisation for autonomy faction military vs. economic cooperation (they were doing the opposite of what they informed you). [zijistark]
-	Autonomy faction military and economic cooperation now effect the entire subrealm of each faction member, providing a small but significant realm-level boost to the military or economic might of faction members relative to their liege. A bit more danger for the liege and yet also good for his/her realm if the faction votes for it. [zijistark]
+	Fixed mismatched localisation for autonomy faction military vs. economic cooperation (they were doing the opposite of what they informed you) [zijistark]
+	Autonomy faction military and economic cooperation now effect the entire subrealm of each faction member, providing a small but significant realm-level boost to the military or economic might of faction members relative to their liege. A bit more danger for the liege and yet also good for his/her realm if the faction votes for it [zijistark]
 	The autonomy faction factor from legalism tech now ranges from 0 to 8 instead of -2 to 6
 	Improved the localisation for some CB requirement localisation
 	Fixed Muslim city vassal request event so it works properly when city obligations are set to maximum [AnaxXiphos]
 	Members of the Autonomy faction that have been coerced by their liege's spymaster will now always vote in their liege's favor when it comes to negative actions. They will never vote for the angry faction mood
 	(PB+SWMH) Fixed Imperial Reconquest not working in the French tier
+	Crown law revocation via faction ultimatums or _any kind_ of revolt now induce a cooldown period of 15 years before a crown law may again be revoked via such a mechanism. NOTES: If a claimant of any kind usurps the throne, all CA sliders are reduced regardless of any cooldown, and if present, it's removed. If the liege is deposed, overthrown, or replaced due to a succession war and all CA sliders are reduced due to lack of cooldown protection, a new cooldown period starts for the new liege. Finally, the cooldown is removed from a title if the liege grants it to a new ruler [zijistark]
+	Fixed double-abdication bug with the autonomy faction's abdication ultimatum (child pretenders on the throne, anyone?) [zijistark]
+	Various minor bugfixes for the autonomy faction [zijistark]
+	A succesful autonomy faction revolt to remove a title revocation law will no longer revoke all tiers of the revocation law slider for all of the liege's crown titles at once. One tier will be revoked from the current law of each title instead [zijistark]
+	Successful faction revolts that revoke crown laws no longer "use-up" the liege's once-in-a-lifetime right to change a crown law, if he/she hadn't already changed one beforehand. This was already the case for some faction revolts and is now consistent [zijistark]
 
 3.4.1
 	Updated the implementation of the New Duel Engine to its latest version

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -13,7 +13,6 @@
 	Crown law revocation via faction ultimatums or _any kind_ of revolt now induce a cooldown period of 15 years before a crown law may again be revoked via such a mechanism. NOTES: If a claimant of any kind usurps the throne, all CA sliders are reduced regardless of any cooldown, and if present, it's removed. If the liege is deposed, overthrown, or replaced due to a succession war and all CA sliders are reduced due to lack of cooldown protection, a new cooldown period starts for the new liege. Finally, the cooldown is removed from a title if the liege grants it to a new ruler [zijistark]
 	Fixed double-abdication bug with the autonomy faction's abdication ultimatum (child pretenders on the throne, anyone?) [zijistark]
 	Various minor bugfixes for the autonomy faction [zijistark]
-	A succesful autonomy faction revolt to remove a title revocation law will no longer revoke all tiers of the revocation law slider for all of the liege's crown titles at once. One tier will be revoked from the current law of each title instead [zijistark]
 	Successful faction revolts that revoke crown laws no longer "use-up" the liege's once-in-a-lifetime right to change a crown law, if he/she hadn't already changed one beforehand. This was already the case for some faction revolts and is now consistent [zijistark]
 
 3.4.1

--- a/ProjectBalance/common/cb_types/ProjectBalance.txt
+++ b/ProjectBalance/common/cb_types/ProjectBalance.txt
@@ -8,6 +8,17 @@ remove_internal_peace = {
 	can_ask_to_join_war = no
 	
 	can_use = {
+		FROM = {
+			NOT = { has_character_modifier = ca_revoke_cooldown }
+			any_demesne_title = {
+				OR = {
+					has_law = emperor_peace_2
+					has_law = emperor_peace_1
+					has_law = king_peace_2
+					has_law = king_peace_1
+				}
+			}
+		}
 		ROOT = {
 			vassal_of = FROM
 			has_character_flag = faction_autonomy_no_internal_peace
@@ -41,11 +52,18 @@ remove_internal_peace = {
 			any_demesne_title = {
 				if = {
 					limit = { tier = king }
-					add_law_w_cooldown = king_peace_0
+					add_law = king_peace_0
 				}
 				if = {
 					limit = { tier = emperor }
-					add_law_w_cooldown = emperor_peace_0
+					add_law = emperor_peace_0
+				}
+			}
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
 				}
 			}
 		}
@@ -124,6 +142,15 @@ remove_revokation = {
 	can_ask_to_join_war = no
 	
 	can_use = {
+		FROM = {
+			NOT = { has_character_modifier = ca_revoke_cooldown }
+			any_demesne_title = {
+				OR = {
+					has_law = revokation_1
+					has_law = revokation_2
+				}
+			}
+		}
 		ROOT = {
 			vassal_of = FROM
 			has_character_flag = faction_autonomy_no_revocation
@@ -155,13 +182,19 @@ remove_revokation = {
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 		FROM = {
 			any_demesne_title = {
-				limit = {
-					OR = {
-						has_law = revokation_1
-						has_law = revokation_2
-					}
+				limit = { has_law = revokation_1 }
+				add_law = revokation_0
+			}
+			any_demesne_title = {
+				limit = { has_law = revokation_2 }
+				add_law = revokation_1
+			}
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
 				}
-				add_law_w_cooldown = revokation_0
 			}
 		}
 		FROM = { clr_character_flag = autonomy_faction_revolt }
@@ -239,6 +272,10 @@ remove_inheritance = {
 	can_ask_to_join_war = no
 	
 	can_use = {
+		FROM = {
+			NOT = { has_character_modifier = ca_revoke_cooldown }
+			any_demesne_title = { has_law = inheritance_1 }
+		}
 		ROOT = {
 			vassal_of = FROM
 			has_character_flag = faction_autonomy_external_inheritance
@@ -271,7 +308,14 @@ remove_inheritance = {
 		FROM = {
 			any_demesne_title = {
 				limit = { has_law = inheritance_1 }
-				add_law_w_cooldown = inheritance_0
+				add_law = inheritance_0
+			}
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
+				}
 			}
 		}
 		FROM = { clr_character_flag = autonomy_faction_revolt }
@@ -340,6 +384,7 @@ remove_inheritance = {
 	}
 }
 
+# also for merely reducing obligations when crown levies cannot be reduced
 reduce_crown_levies = {
 	name = CB_NAME_REDUCE_CROWN_LEVIES
 	war_name = WAR_NAME_REDUCE_CROWN_LEVIES
@@ -378,24 +423,45 @@ reduce_crown_levies = {
 		}
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 		FROM = {
-			any_demesne_title = {
-				if = {
-					limit = { has_law = crown_levies_1 }
-					add_law_w_cooldown = crown_levies_0
+			if = {
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						OR = {
+							has_law = crown_levies_1
+							has_law = crown_levies_2
+							has_law = crown_levies_3
+							has_law = crown_levies_4
+						}
+					}
 				}
-				if = {
-					limit = { has_law = crown_levies_2 }
-					add_law_w_cooldown = crown_levies_1
+				any_demesne_title = {
+					if = {
+						limit = { has_law = crown_levies_1 }
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = { has_law = crown_levies_2 }
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = { has_law = crown_levies_3 }
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = { has_law = crown_levies_4 }
+						add_law = crown_levies_3
+					}
 				}
-				if = {
-					limit = { has_law = crown_levies_3 }
-					add_law_w_cooldown = crown_levies_2
-				}
-				if = {
-					limit = { has_law = crown_levies_4 }
-					add_law_w_cooldown = crown_levies_3
+				hidden_tooltip = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
 				}
 			}
+				
 			if = {
 				limit = { has_law = feudal_obligations_1 }
 				primary_title = { add_law = feudal_obligations_0 }

--- a/ProjectBalance/common/cb_types/ProjectBalance.txt
+++ b/ProjectBalance/common/cb_types/ProjectBalance.txt
@@ -182,12 +182,13 @@ remove_revokation = {
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 		FROM = {
 			any_demesne_title = {
-				limit = { has_law = revokation_1 }
+				limit = {
+					OR = {
+						has_law = revokation_1
+						has_law = revokation_2
+					}
+				}
 				add_law = revokation_0
-			}
-			any_demesne_title = {
-				limit = { has_law = revokation_2 }
-				add_law = revokation_1
 			}
 			hidden_tooltip = {
 				add_character_modifier = {

--- a/ProjectBalance/common/cb_types/ProjectBalance.txt
+++ b/ProjectBalance/common/cb_types/ProjectBalance.txt
@@ -59,11 +59,14 @@ remove_internal_peace = {
 					add_law = emperor_peace_0
 				}
 			}
-			hidden_tooltip = {
-				add_character_modifier = {
-					name = ca_revoke_cooldown
-					duration = 5475
-					inherit = yes
+			custom_tooltip = {
+				text = ca_revoke_cooldown_ctt
+				hidden_tooltip = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
 				}
 			}
 		}
@@ -190,11 +193,14 @@ remove_revokation = {
 				}
 				add_law = revokation_0
 			}
-			hidden_tooltip = {
-				add_character_modifier = {
-					name = ca_revoke_cooldown
-					duration = 5475
-					inherit = yes
+			custom_tooltip = {
+				text = ca_revoke_cooldown_ctt
+				hidden_tooltip = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
 				}
 			}
 		}
@@ -311,11 +317,14 @@ remove_inheritance = {
 				limit = { has_law = inheritance_1 }
 				add_law = inheritance_0
 			}
-			hidden_tooltip = {
-				add_character_modifier = {
-					name = ca_revoke_cooldown
-					duration = 5475
-					inherit = yes
+			custom_tooltip = {
+				text = ca_revoke_cooldown_ctt
+				hidden_tooltip = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
 				}
 			}
 		}
@@ -454,11 +463,14 @@ reduce_crown_levies = {
 						add_law = crown_levies_3
 					}
 				}
-				hidden_tooltip = {
-					add_character_modifier = {
-						name = ca_revoke_cooldown
-						duration = 5475
-						inherit = yes
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
+						}
 					}
 				}
 			}

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -1918,16 +1918,11 @@ change_seniority_succession_law = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
-						OR = { # in other words, every case but all laws being at min.
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
 							NOT = { has_law = inheritance_0 }
@@ -1935,20 +1930,23 @@ change_seniority_succession_law = {
 								NOT = { has_law = king_peace_0 }
 								NOT = { has_law = emperor_peace_0 }
 							}
-						}						
+						}
 					}
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
-					
-					# NOTE: as the effect of this scope is not terribly obvious in its
+					# NOTE: as the effect of this scope was not terribly obvious in its
 					# ability to answer the question "is a CA reduction always guaranteed?"
 					# I did formally verify it in combination with the limit trigger,
 					# and, indeed, 89 of the 90 possible law combinations (combining king's
 					# and emperor's peace) must change at least one law, and 90th case is
-					# filtered out by the limit trigger, FWIW.  it's reused as boilerplate
-					# extensively, hence the comment. (and even if the limit trigger were
-					# gone, the 90th case would have no practical effect, as we'd already
-					# be at min. CA-- inheritance_0 would get reset)
+					# just zero CA.  it's reused as boilerplate extensively, so I modified
+					# the effect to take account of the 90th case and moved the trigger to
+					# the outer limit where it determines whether it's a valid case to add
+					# the CA revocation cooldown, most importantly not using any temp. flags
+					# so that a custom tooltip can be used for the cooldown.
 					
 					if = {
 						limit = {
@@ -1958,6 +1956,7 @@ change_seniority_succession_law = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -2038,8 +2037,8 @@ change_seniority_succession_law = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -2048,8 +2047,6 @@ change_seniority_succession_law = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -2177,15 +2174,10 @@ change_primogeniture_succession_law = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -2196,8 +2188,10 @@ change_primogeniture_succession_law = {
 							}
 						}
 					}
-					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
 					if = {
 						limit = {
@@ -2207,6 +2201,7 @@ change_primogeniture_succession_law = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -2287,8 +2282,8 @@ change_primogeniture_succession_law = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -2297,8 +2292,6 @@ change_primogeniture_succession_law = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -2425,15 +2418,10 @@ change_feudal_elective_succession_law = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -2444,8 +2432,10 @@ change_feudal_elective_succession_law = {
 							}
 						}
 					}
-					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
 					if = {
 						limit = {
@@ -2455,6 +2445,7 @@ change_feudal_elective_succession_law = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -2535,8 +2526,8 @@ change_feudal_elective_succession_law = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -2545,8 +2536,6 @@ change_feudal_elective_succession_law = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -4456,17 +4445,11 @@ bid_for_independence = {
 		}
 
 		FROM = {
-			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -4477,8 +4460,10 @@ bid_for_independence = {
 							}
 						}
 					}
-					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
 					if = {
 						limit = {
@@ -4488,6 +4473,7 @@ bid_for_independence = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -4568,8 +4554,8 @@ bid_for_independence = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -4578,8 +4564,6 @@ bid_for_independence = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 	}
@@ -4712,17 +4696,14 @@ depose_liege = {
 
 	on_success = {
 		FROM = {
-			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+				}
 				
 				any_demesne_title = { # All titles
 					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -4734,7 +4715,13 @@ depose_liege = {
 						}
 					}
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+					# for the three CBs which result in a liege unknown a priori,
+					# we don't bother with getting the custom tooltip right, and
+					# we just make sure that the cooldown is set in the right cases.
+					# these CBs are: depose_liege (this), overthrow_ruler, and
+					#                overthrow_ruler_no_calls
+					
+					PREV = { set_character_flag = ca_revoke_cooldown_temp }
 					
 					if = {
 						limit = {
@@ -4823,12 +4810,12 @@ depose_liege = {
 						add_law = emperor_peace_0
 					}
 				} # END: All titles
-			} # END: unless CA reduction cooldown
-			
+			}
+
 			abdicate_to_most_liked_by = ROOT
-			
+				
 			if = {
-				limit = { has_character_flag = ca_law_revoked_temp }
+				limit = { has_character_flag = ca_revoke_cooldown_temp }
 				hidden_tooltip = {
 					ROOT = {
 						liege = {
@@ -4841,8 +4828,8 @@ depose_liege = {
 					}
 				}
 			}
-				
-			clr_character_flag = ca_law_revoked_temp
+			
+			clr_character_flag = ca_revoke_cooldown_temp
 		}
 		any_attacker = {
 			limit = { character = ROOT }
@@ -4950,17 +4937,14 @@ overthrow_ruler = {
 				who = ROOT
 				modifier = declared_war
 			}
-			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+				}
 				
 				any_demesne_title = { # All titles
 					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -4972,7 +4956,11 @@ overthrow_ruler = {
 						}
 					}
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+					# for the two CBs which result in a liege unknown a priori,
+					# we don't bother with getting the custom tooltip right, and
+					# we just make sure that the cooldown is set in the right cases.
+					
+					PREV = { set_character_flag = ca_revoke_cooldown_temp }
 					
 					if = {
 						limit = {
@@ -5059,20 +5047,19 @@ overthrow_ruler = {
 							}
 						}
 						add_law = emperor_peace_0
-						FROM = { set_character_flag = ca_law_revoked_temp }
 					}
 				} # END: All titles
 			}
-			
+
 			current_heir = {
 				prestige = -200
 				inherit = PREV
 			}
 			
 			abdicate = yes
-			
+				
 			if = {
-				limit = { has_character_flag = ca_law_revoked_temp }
+				limit = { has_character_flag = ca_revoke_cooldown_temp }
 				hidden_tooltip = {
 					ROOT = {
 						liege = {
@@ -5086,7 +5073,7 @@ overthrow_ruler = {
 				}
 			}
 			
-			clr_character_flag = ca_law_revoked_temp
+			clr_character_flag = ca_revoke_cooldown_temp
 		}
 		any_attacker = {
 			limit = { character = ROOT }
@@ -5427,11 +5414,7 @@ succession_on_liege = {
 		if = {
 			limit = {
 				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
-				OR = {
-					tier = king
-					tier = emperor
-				}
-#				is_titular = no
+				higher_tier_than = duke
 				OR = {
 					NOT = { has_law = crown_levies_0 }
 					NOT = { has_law = revokation_0 }
@@ -5442,6 +5425,12 @@ succession_on_liege = {
 					}
 				}
 			}
+			
+			# like depose_liege, overthrow_ruler, and overthrow_ruler_no_calls (unknown new liege),
+			# we also don't bother with generating a tooltip that includes whether or not a revocation
+			# cooldown is to be enacted on ROOT for succession wars, because they are per-title, and
+			# there's no simple trigger to tell us, after the fact, that a crown law was indeed
+			# revoked (without the use of flags, which won't do for a tooltip).
 			
 			FROM = { set_character_flag = ca_law_revoked_temp }
 					
@@ -5684,11 +5673,7 @@ other_succession = {
 		if = {
 			limit = {
 				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
-				OR = {
-					tier = king
-					tier = emperor
-				}
-#				is_titular = no
+				higher_tier_than = duke
 				OR = {
 					NOT = { has_law = crown_levies_0 }
 					NOT = { has_law = revokation_0 }
@@ -5792,7 +5777,8 @@ other_succession = {
 		
 		# NOTE: this may add the cooldown modifier multiple times in a row
 		# (due to multiple crown law titles transferred), but that will do
-		# no harm.
+		# no harm.  we could add it to post-title, but I'd rather limit the
+		# scope of the temp. flag.
 		
 		if = { limit = { FROM = { has_character_flag = ca_law_revoked_temp } }
 			hidden_tooltip = {
@@ -5945,6 +5931,12 @@ other_succession_on_liege = {
 		}
 		
 		FROM = {
+			# you'd think we could add the tooltipped revocation cooldown to
+			# the successful pretender here a priori, but there is no way to
+			# scope to this CB instance's affected titles, so any_demesne_title
+			# won't work as per usual. they aren't the same-tier titles as the
+			# snippet below might suggest at first either.
+		
 			any_demesne_title = {
 				limit = {
 					tier = FROM
@@ -5966,11 +5958,7 @@ other_succession_on_liege = {
 		if = {
 			limit = {
 				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
-				OR = {
-					tier = king
-					tier = emperor
-				}
-#				is_titular = no
+				higher_tier_than = duke
 				OR = {
 					NOT = { has_law = crown_levies_0 }
 					NOT = { has_law = revokation_0 }
@@ -6071,10 +6059,6 @@ other_succession_on_liege = {
 				add_law = emperor_peace_0
 			}
 		} # END: if title needs a CA reduction
-		
-		# NOTE: this may add the cooldown modifier multiple times in a row
-		# (due to multiple crown law titles transferred), but that will do
-		# no harm.
 		
 		if = { limit = { FROM = { has_character_flag = ca_law_revoked_temp } }
 			hidden_tooltip = {
@@ -6965,15 +6949,10 @@ change_gavelkind_succession_law = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -6984,8 +6963,21 @@ change_gavelkind_succession_law = {
 							}
 						}
 					}
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+					# NOTE: as the effect of this scope was not terribly obvious in its
+					# ability to answer the question "is a CA reduction always guaranteed?"
+					# I did formally verify it in combination with the limit trigger,
+					# and, indeed, 89 of the 90 possible law combinations (combining king's
+					# and emperor's peace) must change at least one law, and 90th case is
+					# just zero CA.  it's reused as boilerplate extensively, so I modified
+					# the effect to take account of the 90th case and moved the trigger to
+					# the outer limit where it determines whether it's a valid case to add
+					# the CA revocation cooldown, most importantly not using any temp. flags
+					# so that a custom tooltip can be used for the cooldown.
 					
 					if = {
 						limit = {
@@ -6995,6 +6987,7 @@ change_gavelkind_succession_law = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -7075,8 +7068,8 @@ change_gavelkind_succession_law = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -7085,8 +7078,6 @@ change_gavelkind_succession_law = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -7561,16 +7552,13 @@ weaken_vassal_plot = {
 			participation_scaled_prestige = 100
 		}
 		FROM = {
+			hidden_tooltip = { disband_event_forces = faction_loyalists }
+			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -7581,8 +7569,21 @@ weaken_vassal_plot = {
 							}
 						}
 					}
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+					# NOTE: as the effect of this scope was not terribly obvious in its
+					# ability to answer the question "is a CA reduction always guaranteed?"
+					# I did formally verify it in combination with the limit trigger,
+					# and, indeed, 89 of the 90 possible law combinations (combining king's
+					# and emperor's peace) must change at least one law, and 90th case is
+					# just zero CA.  it's reused as boilerplate extensively, so I modified
+					# the effect to take account of the 90th case and moved the trigger to
+					# the outer limit where it determines whether it's a valid case to add
+					# the CA revocation cooldown, most importantly not using any temp. flags
+					# so that a custom tooltip can be used for the cooldown.
 					
 					if = {
 						limit = {
@@ -7592,6 +7593,7 @@ weaken_vassal_plot = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -7672,8 +7674,8 @@ weaken_vassal_plot = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -7682,8 +7684,6 @@ weaken_vassal_plot = {
 						}
 					}
 				}
-				
-				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 	}
@@ -8556,19 +8556,13 @@ cb_faction_independence = {
 		}
 
 		FROM = {
-			
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
 			if = {
-				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-				
-				any_demesne_title = { # All titles
-					limit = {
-						OR = {
-							tier = king
-							tier = emperor
-						}
-#						is_titular = no
+				limit = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						higher_tier_than = duke
 						OR = {
 							NOT = { has_law = crown_levies_0 }
 							NOT = { has_law = revokation_0 }
@@ -8579,8 +8573,21 @@ cb_faction_independence = {
 							}
 						}
 					}
+				}
+				
+				any_demesne_title = { # All titles
+					limit = { higher_tier_than = duke }
 					
-					PREV = { set_character_flag = ca_law_revoked_temp }
+					# NOTE: as the effect of this scope was not terribly obvious in its
+					# ability to answer the question "is a CA reduction always guaranteed?"
+					# I did formally verify it in combination with the limit trigger,
+					# and, indeed, 89 of the 90 possible law combinations (combining king's
+					# and emperor's peace) must change at least one law, and 90th case is
+					# just zero CA.  it's reused as boilerplate extensively, so I modified
+					# the effect to take account of the 90th case and moved the trigger to
+					# the outer limit where it determines whether it's a valid case to add
+					# the CA revocation cooldown, most importantly not using any temp. flags
+					# so that a custom tooltip can be used for the cooldown.
 					
 					if = {
 						limit = {
@@ -8590,6 +8597,7 @@ cb_faction_independence = {
 							}
 							has_law = revokation_0
 							has_law = crown_levies_0
+							NOT = { has_law = inheritance_0 }
 						}
 						add_law = inheritance_0
 					}
@@ -8670,8 +8678,8 @@ cb_faction_independence = {
 					}
 				} # END: All titles
 
-				if = {
-					limit = { has_character_flag = ca_law_revoked_temp }
+				custom_tooltip = {
+					text = ca_revoke_cooldown_ctt
 					hidden_tooltip = {
 						add_character_modifier = {
 							name = ca_revoke_cooldown
@@ -8679,23 +8687,6 @@ cb_faction_independence = {
 							inherit = yes
 						}
 					}
-				}
-				
-				clr_character_flag = ca_law_revoked_temp
-			}
-		}
-		if = {
-			limit = {
-				FROM = { has_landed_title = e_hre }
-			}
-			FROM = {
-				any_vassal = {
-					limit = {
-						NOT = { 
-							any_realm_title = { de_jure_liege_or_above = e_hre }
-						}
-					}
-					set_defacto_liege = THIS
 				}
 			}
 		}

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -1916,110 +1916,140 @@ change_seniority_succession_law = {
 	on_success = {
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = { # in other words, every case but all laws being at min.
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}						
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					# NOTE: as the effect of this scope is not terribly obvious in its
+					# ability to answer the question "is a CA reduction always guaranteed?"
+					# I did formally verify it in combination with the limit trigger,
+					# and, indeed, 89 of the 90 possible law combinations (combining king's
+					# and emperor's peace) must change at least one law, and 90th case is
+					# filtered out by the limit trigger, FWIW.  it's reused as boilerplate
+					# extensively, hence the comment. (and even if the limit trigger were
+					# gone, the 90th case would have no practical effect, as we'd already
+					# be at min. CA-- inheritance_0 would get reset)
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}	
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -2145,110 +2175,130 @@ change_primogeniture_succession_law = {
 	on_success = {
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}	
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -2373,110 +2423,130 @@ change_feudal_elective_succession_law = {
 	on_success = {
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}	
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -4386,110 +4456,130 @@ bid_for_independence = {
 		}
 
 		FROM = {
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 	}
@@ -4622,112 +4712,137 @@ depose_liege = {
 
 	on_success = {
 		FROM = {
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
-					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
-					}
-				}
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
 				
-				if = {
+				any_demesne_title = { # All titles
 					limit = {
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							tier = king
+							tier = emperor
 						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
+#						is_titular = no
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
 						}
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
 						}
+						add_law = inheritance_0
 					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
 						}
+						add_law = crown_levies_0
 					}
-					add_law = emperor_peace_0
-				}	
-			}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+			} # END: unless CA reduction cooldown
+			
 			abdicate_to_most_liked_by = ROOT
+			
+			if = {
+				limit = { has_character_flag = ca_law_revoked_temp }
+				hidden_tooltip = {
+					ROOT = {
+						liege = {
+							add_character_modifier = {
+								name = ca_revoke_cooldown
+								duration = 5475
+								inherit = yes
+							}
+						}
+					}
+				}
+			}
+				
+			clr_character_flag = ca_law_revoked_temp
 		}
 		any_attacker = {
 			limit = { character = ROOT }
@@ -4835,116 +4950,143 @@ overthrow_ruler = {
 				who = ROOT
 				modifier = declared_war
 			}
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
-					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
-					}
-				}
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
 				
-				if = {
+				any_demesne_title = { # All titles
 					limit = {
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							tier = king
+							tier = emperor
 						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
+#						is_titular = no
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
 						}
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
 						}
+						add_law = inheritance_0
 					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
 						}
+						add_law = crown_levies_0
 					}
-					add_law = emperor_peace_0
-				}	
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+						FROM = { set_character_flag = ca_law_revoked_temp }
+					}
+				} # END: All titles
 			}
+			
 			current_heir = {
 				prestige = -200
 				inherit = PREV
 			}
+			
 			abdicate = yes
+			
+			if = {
+				limit = { has_character_flag = ca_law_revoked_temp }
+				hidden_tooltip = {
+					ROOT = {
+						liege = {
+							add_character_modifier = {
+								name = ca_revoke_cooldown
+								duration = 5475
+								inherit = yes
+							}
+						}
+					}
+				}
+			}
+			
+			clr_character_flag = ca_law_revoked_temp
 		}
 		any_attacker = {
 			limit = { character = ROOT }
@@ -5058,112 +5200,137 @@ overthrow_ruler_no_calls = {
 				who = ROOT
 				modifier = declared_war
 			}
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
-					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
-					}
-				}
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
 				
-				if = {
+				any_demesne_title = { # All titles
 					limit = {
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							tier = king
+							tier = emperor
 						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
+#						is_titular = no
 						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
 						}
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
 						}
+						add_law = inheritance_0
 					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
 						}
+						add_law = crown_levies_0
 					}
-					add_law = emperor_peace_0
-				}	
-			}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+			} # END: unless CA reduction cooldown
+			
 			abdicate = yes
+			
+			if = {
+				limit = { has_character_flag = ca_law_revoked_temp }
+				hidden_tooltip = {
+					ROOT = {
+						liege = {
+							add_character_modifier = {
+								name = ca_revoke_cooldown
+								duration = 5475
+								inherit = yes
+							}
+						}
+					}
+				}
+			}
+				
+			clr_character_flag = ca_law_revoked_temp
 		}
 	}
 
@@ -5259,109 +5426,131 @@ succession_on_liege = {
 	on_success_title = {
 		if = {
 			limit = {
+				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
 				OR = {
 					tier = king
 					tier = emperor
 				}
 #				is_titular = no
 				OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
+					NOT = { has_law = crown_levies_0 }
+					NOT = { has_law = revokation_0 }
+					NOT = { has_law = inheritance_0 }
+					AND = {
+						NOT = { has_law = king_peace_0 }
+						NOT = { has_law = emperor_peace_0 }
 					}
 				}
-				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
+			}
+			
+			FROM = { set_character_flag = ca_law_revoked_temp }
+					
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = inheritance_0
+					has_law = revokation_0
+					has_law = crown_levies_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = inheritance_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_1
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_0
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_2
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_1
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_1
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_3
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_2
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_2
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_4
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_3
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
+				add_law = crown_levies_3
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = revokation_1
+						has_law = revokation_2
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = king_peace_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
+				add_law = revokation_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_1
+						has_law = king_peace_2
 					}
-					add_law = emperor_peace_0
 				}
+				add_law = king_peace_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = emperor_peace_1
+						has_law = emperor_peace_2
+					}
+				}
+				add_law = emperor_peace_0
+			}
+		} # END: if title needs a CA reduction
+		
+		# NOTE: this may add the cooldown modifier multiple times in a row
+		# (due to multiple crown law titles transferred), but that will do
+		# no harm.  could restructure the CB a bit and avoid it, but this
+		# is minimal.
+		
+		if = { limit = { FROM = { has_character_flag = ca_law_revoked_temp } }
+			hidden_tooltip = {
+				ROOT = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
+				}
+			}
 		}
+		
+		FROM = { clr_character_flag = ca_law_revoked_temp }
 	}
 	
 	on_fail = {
@@ -5494,109 +5683,130 @@ other_succession = {
 		usurp_title_plus_barony_if_unlanded = ROOT
 		if = {
 			limit = {
+				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
 				OR = {
 					tier = king
 					tier = emperor
 				}
 #				is_titular = no
 				OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
+					NOT = { has_law = crown_levies_0 }
+					NOT = { has_law = revokation_0 }
+					NOT = { has_law = inheritance_0 }
+					AND = {
+						NOT = { has_law = king_peace_0 }
+						NOT = { has_law = emperor_peace_0 }
 					}
 				}
-				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
+			}
+			
+			FROM = { set_character_flag = ca_law_revoked_temp }
+
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = inheritance_0
+					has_law = revokation_0
+					has_law = crown_levies_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = inheritance_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_1
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_0
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_2
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_1
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_1
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_3
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_2
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_2
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_4
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_3
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
+				add_law = crown_levies_3
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = revokation_1
+						has_law = revokation_2
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = king_peace_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
+				add_law = revokation_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_1
+						has_law = king_peace_2
 					}
-					add_law = emperor_peace_0
 				}
+				add_law = king_peace_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = emperor_peace_1
+						has_law = emperor_peace_2
+					}
+				}
+				add_law = emperor_peace_0
+			}
+		} # END: if title needs a CA reduction
+		
+		# NOTE: this may add the cooldown modifier multiple times in a row
+		# (due to multiple crown law titles transferred), but that will do
+		# no harm.
+		
+		if = { limit = { FROM = { has_character_flag = ca_law_revoked_temp } }
+			hidden_tooltip = {
+				ROOT = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
+				}
+			}
 		}
+		
+		FROM = { clr_character_flag = ca_law_revoked_temp }
 	}
 
 	on_success_posttitle = {
@@ -5755,109 +5965,130 @@ other_succession_on_liege = {
 	on_success_title = {
 		if = {
 			limit = {
+				NOT = { FROM = { has_character_modifier = ca_revoke_cooldown } }
 				OR = {
 					tier = king
 					tier = emperor
 				}
 #				is_titular = no
 				OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
-						}
+					NOT = { has_law = crown_levies_0 }
+					NOT = { has_law = revokation_0 }
+					NOT = { has_law = inheritance_0 }
+					AND = {
+						NOT = { has_law = king_peace_0 }
+						NOT = { has_law = emperor_peace_0 }
 					}
 				}
-				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
+			}
+			
+			FROM = { set_character_flag = ca_law_revoked_temp }
+
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = inheritance_0
+					has_law = revokation_0
+					has_law = crown_levies_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = inheritance_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_1
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_0
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_0
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_2
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_1
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_1
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_3
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_2
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
+				add_law = crown_levies_2
+			}
+			if = {
+				limit = {
+					has_law = crown_levies_4
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = crown_levies_3
+					has_law = revokation_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
+				add_law = crown_levies_3
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = revokation_1
+						has_law = revokation_2
 					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
+					OR = {
+						has_law = king_peace_0
+						has_law = emperor_peace_0
 					}
-					add_law = king_peace_0
 				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
+				add_law = revokation_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = king_peace_1
+						has_law = king_peace_2
 					}
-					add_law = emperor_peace_0
 				}
+				add_law = king_peace_0
+			}
+			if = {
+				limit = {
+					OR = {
+						has_law = emperor_peace_1
+						has_law = emperor_peace_2
+					}
+				}
+				add_law = emperor_peace_0
+			}
+		} # END: if title needs a CA reduction
+		
+		# NOTE: this may add the cooldown modifier multiple times in a row
+		# (due to multiple crown law titles transferred), but that will do
+		# no harm.
+		
+		if = { limit = { FROM = { has_character_flag = ca_law_revoked_temp } }
+			hidden_tooltip = {
+				ROOT = {
+					add_character_modifier = {
+						name = ca_revoke_cooldown
+						duration = 5475
+						inherit = yes
+					}
+				}
+			}
 		}
+		
+		FROM = { clr_character_flag = ca_law_revoked_temp }
 	}
 
 	on_success_posttitle = {
@@ -6732,110 +6963,130 @@ change_gavelkind_succession_law = {
 	on_success = {
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		any_attacker = {
@@ -7310,110 +7561,129 @@ weaken_vassal_plot = {
 			participation_scaled_prestige = 100
 		}
 		FROM = {
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 	}
@@ -8288,111 +8558,130 @@ cb_faction_independence = {
 		FROM = {
 			
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
-		
-			any_demesne_title = { # All titles
-				limit = {
-					OR = {
-						tier = king
-						tier = emperor
+			
+			if = {
+				limit = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+				
+				any_demesne_title = { # All titles
+					limit = {
+						OR = {
+							tier = king
+							tier = emperor
+						}
+#						is_titular = no
+						OR = {
+							NOT = { has_law = crown_levies_0 }
+							NOT = { has_law = revokation_0 }
+							NOT = { has_law = inheritance_0 }
+							AND = {
+								NOT = { has_law = king_peace_0 }
+								NOT = { has_law = emperor_peace_0 }
+							}
+						}
 					}
-#					is_titular = no
-					OR = {
-						NOT = { has_law = crown_levies_0 }
-						NOT = { has_law = revokation_0 }
-						NOT = { has_law = inheritance_0 }
-						AND = {
-							NOT = { has_law = king_peace_0 }
-							NOT = { has_law = emperor_peace_0 }
+					
+					PREV = { set_character_flag = ca_law_revoked_temp }
+					
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+							has_law = crown_levies_0
+						}
+						add_law = inheritance_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_1
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_0
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_2
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_1
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_3
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_2
+					}
+					if = {
+						limit = {
+							has_law = crown_levies_4
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+							has_law = revokation_0
+						}
+						add_law = crown_levies_3
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = revokation_1
+								has_law = revokation_2
+							}
+							OR = {
+								has_law = king_peace_0
+								has_law = emperor_peace_0
+							}
+						}
+						add_law = revokation_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = king_peace_1
+								has_law = king_peace_2
+							}
+						}
+						add_law = king_peace_0
+					}
+					if = {
+						limit = {
+							OR = {
+								has_law = emperor_peace_1
+								has_law = emperor_peace_2
+							}
+						}
+						add_law = emperor_peace_0
+					}
+				} # END: All titles
+
+				if = {
+					limit = { has_character_flag = ca_law_revoked_temp }
+					hidden_tooltip = {
+						add_character_modifier = {
+							name = ca_revoke_cooldown
+							duration = 5475
+							inherit = yes
 						}
 					}
 				}
 				
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-						has_law = crown_levies_0
-					}
-					add_law = inheritance_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_1
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_0
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_2
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_1
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_3
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_2
-				}
-				if = {
-					limit = {
-						has_law = crown_levies_4
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-						has_law = revokation_0
-					}
-					add_law = crown_levies_3
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = revokation_1
-							has_law = revokation_2
-						}
-						OR = {
-							has_law = king_peace_0
-							has_law = emperor_peace_0
-						}
-					}
-					add_law = revokation_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = king_peace_1
-							has_law = king_peace_2
-						}
-					}
-					add_law = king_peace_0
-				}
-				if = {
-					limit = {
-						OR = {
-							has_law = emperor_peace_1
-							has_law = emperor_peace_2
-						}
-					}
-					add_law = emperor_peace_0
-				}	
+				clr_character_flag = ca_law_revoked_temp
 			}
 		}
 		if = {

--- a/ProjectBalance/common/event_modifiers/balansegang.txt
+++ b/ProjectBalance/common/event_modifiers/balansegang.txt
@@ -126,3 +126,10 @@ autonomy_commended = {
 	vassal_opinion = 5
 	monthly_character_prestige = 0.25
 }
+
+# Crown law revocation cooldown (CA-only-- investiture excluded).
+# Inherited and pinned on the liege.
+
+ca_revoke_cooldown = {
+	icon = 11
+}

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -2380,10 +2380,15 @@ character_event = {
 			limit = { has_law = crown_levies_4 }
 			add_law = crown_levies_3
 		}
-		add_character_modifier = {
-			name = ca_revoke_cooldown
-			duration = 5475
-			inherit = yes
+		custom_tooltip = {
+			text = ca_revoke_cooldown_ctt
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
+				}
+			}
 		}
 		any_vassal = {
 			limit = {
@@ -2771,10 +2776,15 @@ character_event = {
 			}
 			add_law = revokation_0
 		}
-		add_character_modifier = {
-			name = ca_revoke_cooldown
-			duration = 5475
-			inherit = yes
+		custom_tooltip = {
+			text = ca_revoke_cooldown_ctt
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
+				}
+			}
 		}
 		any_vassal = {
 			limit = {
@@ -3002,8 +3012,6 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
-	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-	
 	option = {
 		name = Yes
 		any_demesne_title = {
@@ -3020,10 +3028,15 @@ character_event = {
 			}
 			add_law = emperor_peace_0
 		}
-		add_character_modifier = {
-			name = ca_revoke_cooldown
-			duration = 5475
-			inherit = yes
+		custom_tooltip = {
+			text = ca_revoke_cooldown_ctt
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
+				}
+			}
 		}
 		any_vassal = {
 			limit = {
@@ -4049,18 +4062,21 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
-	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-	
 	option = {
 		name = Yes
 		any_demesne_title = {
 			limit = { has_law = inheritance_1 }
 			add_law = inheritance_0
 		}
-		add_character_modifier = {
-			name = ca_revoke_cooldown
-			duration = 5475
-			inherit = yes
+		custom_tooltip = {
+			text = ca_revoke_cooldown_ctt
+			hidden_tooltip = {
+				add_character_modifier = {
+					name = ca_revoke_cooldown
+					duration = 5475
+					inherit = yes
+				}
+			}
 		}
 		any_vassal = {
 			limit = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -74,6 +74,14 @@ character_event = {
 			change_variable = { which = "autonomy_desire" value = -5 }
 		}
 		if = {
+			limit = { liege = { is_close_relative = ROOT } }
+			change_variable = { which = "autonomy_desire" value = -5 }
+		}
+		if = {
+			limit = { liege = { current_heir = { character = ROOT } } } # (only applies to feudal elective)
+			change_variable = { which = "autonomy_desire" value = -5 }
+		}
+		if = {
 			limit = { NOT = { opinion = { who = LIEGE value = -10 } } }
 			change_variable = { which = "autonomy_desire" value = 5 }
 		}
@@ -606,7 +614,7 @@ character_event = {
 			change_variable = { which = "autonomy_personal_mood" value = -5 }
 		}
 		if = {
-			limit = { liege = { trait = possessed } }
+			limit = { liege = { trait = possessed } } # FIXME: game models possessed on Joan d'Arc, manifesting in trait changes only, either all good or all bad.
 			change_variable = { which = "autonomy_personal_mood" value = -5 }
 		}
 		if = {
@@ -633,10 +641,21 @@ character_event = {
 		}
 		if = {
 			limit = {
-				liege = { trait = crusader }
-				liege = { religion = ROOT }
+				liege = {
+					trait = crusader
+					religion = ROOT
+				}
 			}
-			change_variable = { which = "autonomy_personal_mood" value = -2 }
+			change_variable = { which = "autonomy_personal_mood" value = 2 }
+		}
+		if = {
+			limit = {
+				liege = {
+					trait = mujahid
+					religion = ROOT
+				}
+			}
+			change_variable = { which = "autonomy_personal_mood" value = 2 }
 		}
 		if = {
 			limit = { liege = { trait = quick } }
@@ -1109,9 +1128,12 @@ character_event = {
 		name = meneth.236.b
 		trigger = {
 			liege = {
-				OR = {
-					has_law = revokation_1
-					has_law = revokation_2
+				NOT = { has_character_modifier = ca_revoke_cooldown }
+				any_demesne_title = {
+					OR = {
+						has_law = revokation_1
+						has_law = revokation_2
+					}
 				}
 			}
 		}
@@ -1145,11 +1167,14 @@ character_event = {
 		name = meneth.236.c
 		trigger = {
 			liege = {
-				OR = {
-					has_law = king_peace_1
-					has_law = king_peace_2
-					has_law = emperor_peace_1
-					has_law = emperor_peace_2
+				NOT = { has_character_modifier = ca_revoke_cooldown }
+				any_demesne_title = {
+					OR = {
+						has_law = king_peace_1
+						has_law = king_peace_2
+						has_law = emperor_peace_1
+						has_law = emperor_peace_2
+					}
 				}
 			}
 		}
@@ -1184,7 +1209,8 @@ character_event = {
 		name = meneth.236.c
 		trigger = {
 			liege = {
-				has_law = inheritance_1
+				NOT = { has_character_modifier = ca_revoke_cooldown }
+				any_demesne_title = { has_law = inheritance_1 }
 			}
 		}
 		set_character_flag = faction_autonomy_external_inheritance
@@ -1527,10 +1553,6 @@ character_event = {
 			if = {
 				limit = { ROOT = { has_character_flag = faction_autonomy_external_inheritance } }
 				character_event = { id = meneth.245 } #Ultimatum to allow external inheritance
-			}
-			if = {
-				limit = { ROOT = { has_character_flag = faction_autonomy_abdicate } }
-				character_event = { id = meneth.247 } #Ultimatum to abdicate
 			}
 			if = {
 				limit = { ROOT = { has_character_flag = faction_autonomy_abdicate } }
@@ -2332,6 +2354,7 @@ character_event = {
 	option = {
 		name = Yes
 		trigger = {
+			NOT = { has_character_modifier = ca_revoke_cooldown }
 			any_demesne_title = {
 				OR = {
 					has_law = crown_levies_1
@@ -2356,6 +2379,11 @@ character_event = {
 		any_demesne_title = {
 			limit = { has_law = crown_levies_4 }
 			add_law = crown_levies_3
+		}
+		add_character_modifier = {
+			name = ca_revoke_cooldown
+			duration = 5475
+			inherit = yes
 		}
 		any_vassal = {
 			limit = {
@@ -2411,12 +2439,17 @@ character_event = {
 				has_law = feudal_obligations_3
 				has_law = feudal_obligations_4
 			}
-			NOT = {
-				OR = {
-					has_law = crown_levies_1
-					has_law = crown_levies_2
-					has_law = crown_levies_3
-					has_law = crown_levies_4
+			OR = {
+				has_character_modifier = ca_revoke_cooldown
+				NOT = {
+					any_demesne_title = {
+						OR = {
+							has_law = crown_levies_1
+							has_law = crown_levies_2
+							has_law = crown_levies_3
+							has_law = crown_levies_4
+						}
+					}
 				}
 			}
 		}
@@ -2485,12 +2518,15 @@ character_event = {
 		name = Yes
 		trigger = {
 			NOT = {
-				any_demesne_title = {
-					OR = {
-						has_law = crown_levies_1
-						has_law = crown_levies_2
-						has_law = crown_levies_3
-						has_law = crown_levies_4
+				AND = {
+					NOT = { has_character_modifier = ca_revoke_cooldown }
+					any_demesne_title = {
+						OR = {
+							has_law = crown_levies_1
+							has_law = crown_levies_2
+							has_law = crown_levies_3
+							has_law = crown_levies_4
+						}
 					}
 				}
 				has_law = feudal_obligations_1
@@ -2724,16 +2760,22 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
+	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+	
 	option = {
 		name = Yes
 		any_demesne_title = {
-			limit = {
-				OR = {
-					tier = king
-					tier = emperor
-				}
-			}
+			limit = { has_law = revokation_1 }
 			add_law = revokation_0
+		}
+		any_demesne_title = {
+			limit = { has_law = revokation_2 }
+			add_law = revokation_1
+		}
+		add_character_modifier = {
+			name = ca_revoke_cooldown
+			duration = 5475
+			inherit = yes
 		}
 		any_vassal = {
 			limit = {
@@ -2961,19 +3003,28 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
+	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+	
 	option = {
 		name = Yes
 		any_demesne_title = {
 			limit = {
 				tier = king
+				NOT = { has_law = king_peace_0 }
 			}
 			add_law = king_peace_0
 		}
 		any_demesne_title = {
 			limit = {
 				tier = emperor
+				NOT = { has_law = emperor_peace_0 }
 			}
 			add_law = emperor_peace_0
+		}
+		add_character_modifier = {
+			name = ca_revoke_cooldown
+			duration = 5475
+			inherit = yes
 		}
 		any_vassal = {
 			limit = {
@@ -3999,11 +4050,18 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
+	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
+	
 	option = {
 		name = Yes
 		any_demesne_title = {
 			limit = { has_law = inheritance_1 }
 			add_law = inheritance_0
+		}
+		add_character_modifier = {
+			name = ca_revoke_cooldown
+			duration = 5475
+			inherit = yes
 		}
 		any_vassal = {
 			limit = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -2760,17 +2760,16 @@ character_event = {
 	picture = GFX_evt_emissary
 	border = GFX_event_normal_frame_religion
 	
-	trigger = { NOT = { has_character_modifier = ca_revoke_cooldown } }
-	
 	option = {
 		name = Yes
 		any_demesne_title = {
-			limit = { has_law = revokation_1 }
+			limit = {
+				OR = {
+					has_law = revokation_1
+					has_law = revokation_2
+				}
+			}
 			add_law = revokation_0
-		}
-		any_demesne_title = {
-			limit = { has_law = revokation_2 }
-			add_law = revokation_1
 		}
 		add_character_modifier = {
 			name = ca_revoke_cooldown

--- a/ProjectBalance/localisation/PB_effects.csv
+++ b/ProjectBalance/localisation/PB_effects.csv
@@ -30,7 +30,7 @@ af_mil_cooperation_t1;Military cooperation;;;;;;;;;;;;;x
 af_eco_cooperation_t1;Economic cooperation;;;;;;;;;;;;;x
 autonomy_commended;Commended by vassals;;;;;;;;;;;;;x
 ca_revoke_cooldown;Crown law revocation cooldown;;;;;;;;;;;;;x
-ca_revoke_cooldown_desc;Crown authority laws were recently revoked due to a faction ultimatum or revolt. It will take some time before vassals are willing to support their realm's remaining laws being forcibly revoked again, if at all.;;;;;;;;;;;;;x
+ca_revoke_cooldown_desc;Crown authority laws were recently revoked due to a faction ultimatum or revolt. It will take time before the realm's nobles are willing to support the revocation of their remaining laws.;;;;;;;;;;;;;x
 ca_revoke_cooldown_ctt;§Y[This.GetTitledFirstName]§!'s realm enters a crown law revocation cooldown period.\n;;;;;;;;;;;;;x
 rum;Ignore the man behind the curtain;;;;;;;;;;;;;x
 opinion_refused_ultimatum;Refused ultimatum;;;;;;;;;;;;;x

--- a/ProjectBalance/localisation/PB_effects.csv
+++ b/ProjectBalance/localisation/PB_effects.csv
@@ -29,6 +29,8 @@ sahara;Sahara;;;;;;;;;;;;;x
 af_mil_cooperation_t1;Military cooperation;;;;;;;;;;;;;x
 af_eco_cooperation_t1;Economic cooperation;;;;;;;;;;;;;x
 autonomy_commended;Commended by vassals;;;;;;;;;;;;;x
+ca_revoke_cooldown;Crown law revocation cooldown;;;;;;;;;;;;;x
+ca_revoke_cooldown_desc;Crown authority laws were recently revoked due to a faction ultimatum or revolt. It will take some time before vassals are willing to support their realm's remaining laws being forcibly revoked again, if at all.;;;;;;;;;;;;;x
 rum;Ignore the man behind the curtain;;;;;;;;;;;;;x
 opinion_refused_ultimatum;Refused ultimatum;;;;;;;;;;;;;x
 opinion_recently_refused_ultimatum;Recently refused ultimatum;;;;;;;;;;;;;x

--- a/ProjectBalance/localisation/PB_effects.csv
+++ b/ProjectBalance/localisation/PB_effects.csv
@@ -31,6 +31,7 @@ af_eco_cooperation_t1;Economic cooperation;;;;;;;;;;;;;x
 autonomy_commended;Commended by vassals;;;;;;;;;;;;;x
 ca_revoke_cooldown;Crown law revocation cooldown;;;;;;;;;;;;;x
 ca_revoke_cooldown_desc;Crown authority laws were recently revoked due to a faction ultimatum or revolt. It will take some time before vassals are willing to support their realm's remaining laws being forcibly revoked again, if at all.;;;;;;;;;;;;;x
+ca_revoke_cooldown_ctt;§Y[This.GetTitledFirstName]§!'s realm enters a crown law revocation cooldown period.\n;;;;;;;;;;;;;x
 rum;Ignore the man behind the curtain;;;;;;;;;;;;;x
 opinion_refused_ultimatum;Refused ultimatum;;;;;;;;;;;;;x
 opinion_recently_refused_ultimatum;Recently refused ultimatum;;;;;;;;;;;;;x


### PR DESCRIPTION
Tried to stay topic-specific, but it was hard not to fix a relatively small number of inconsistencies and a few bugs while I was processing the same code.  The revocation cooldown period is currently 15 years.  Since almost all revocations in the code completely reset at least one crown law slider, no matter how high it had been previously set, I think this is an appropriate minimum amount of time.

In every case that wouldn't have required a headache of logic changes to comply, custom tooltips always indicate whether a crown law will in fact be reduced and whether a revocation cooldown period will start for the liege.

At first, I'd included a change to the way title revocation was handled, but as that is a separate topic, I reverted it.

Changes may look sweeping in content, but most of the text of these changes consists of the same, though slightly-modified, custom CA reduction boilerplate for PB's laws that preexisted.

This has been tested, but my test coverage has somewhat necessarily been incomplete due to the difficulty of setting up conditions for certain CBs or forcing the proper event chain for an autonomy faction outcome (though I did manually invoke the affected ultimatums that didn't come up naturally).  Certainly, nothing is outright broken, worst-case.
