### PR TITLE
Moderate nerf of elective faction & some consistency fixes

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -15,6 +15,7 @@
 	Various minor bugfixes for the autonomy faction [zijistark]
 	Successful faction revolts that revoke crown laws no longer "use-up" the liege's once-in-a-lifetime right to change a crown law, if he/she hadn't already changed one beforehand. This was already the case for some faction revolts and is now consistent [zijistark]
 	Regular factions (non-autonomy) will now now wait to submit a revolt ultimatum until after their liege is no longer using ANY of the 3 holy war CBs in PB [zijistark]
+	Moderate nerf of the feudal elective faction. The faction is generally more tolerant than the other succession law factions, more easily dissuaded/coerced, less subject to transient issues which will definitely be solved, at least by the AI, in due time, and generally slower to jump to an ultimatum. Testing shows that it's quite possible, e.g., for an AI France to avoid an overwhelming elective faction revolt within 5 years of the 1066 start (previously a problem) but that the faction still remains a threat in those scenarios [zijistark]
 
 3.4.1
 	Updated the implementation of the New Duel Engine to its latest version

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -14,6 +14,7 @@
 	Fixed double-abdication bug with the autonomy faction's abdication ultimatum (child pretenders on the throne, anyone?) [zijistark]
 	Various minor bugfixes for the autonomy faction [zijistark]
 	Successful faction revolts that revoke crown laws no longer "use-up" the liege's once-in-a-lifetime right to change a crown law, if he/she hadn't already changed one beforehand. This was already the case for some faction revolts and is now consistent [zijistark]
+	Regular factions (non-autonomy) will now now wait to submit a revolt ultimatum until after their liege is no longer using ANY of the 3 holy war CBs in PB [zijistark]
 
 3.4.1
 	Updated the implementation of the New Duel Engine to its latest version

--- a/ProjectBalance/common/objectives/00_factions.txt
+++ b/ProjectBalance/common/objectives/00_factions.txt
@@ -1869,7 +1869,10 @@ faction_succ_feudal_elective = {
 		has_law = inheritance_0
 		OR = {
 			has_law = crown_levies_0
-			has_law = crown_levies_1
+			AND = {
+				holder_scope = { ai = no }
+				has_law = crown_levies_1
+			}
 		}
 		
 		OR = {
@@ -1902,6 +1905,11 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0
 			FROM = { prisoner = yes }
+		}
+		
+		modifier = {
+			factor = 0
+			FROM = { has_regent = yes }
 		}
 		
 		modifier = {
@@ -1966,6 +1974,7 @@ faction_succ_feudal_elective = {
 				OR = {
 					NOT = { culture = FROM }
 					NOT = { religion = FROM }
+					NOT = { reverse_opinion = { who = FROM value = 20 } }
 				}
 				any_demesne_title = {
 					OR = {
@@ -1978,7 +1987,7 @@ faction_succ_feudal_elective = {
 						}
 					}
 					any_claimant = {
-						culture = FROM
+						culture_group = FROM # actual requirement is merely a group match
 						religion = FROM
 					}
 				}
@@ -1991,11 +2000,11 @@ faction_succ_feudal_elective = {
 				OR = {
 					AND = {
 						NOT = { leads_faction = faction_succ_feudal_elective }
-						opinion = { who = LIEGE value = 50 } 
+						opinion = { who = LIEGE value = 40 } 
 					}
 					AND = {
 						leads_faction = faction_succ_feudal_elective
-						opinion = { who = LIEGE value = 75 } 
+						opinion = { who = LIEGE value = 50 }
 					}
 				}
 			}
@@ -2012,17 +2021,17 @@ faction_succ_feudal_elective = {
 				OR = {
 					AND = {
 						NOT = { leads_faction = faction_succ_feudal_elective }
-						liege = { 
+						PREV = { # actual heir of title in question, not liege
 							current_heir = {
-								reverse_opinion = { who = FROM value = 50 }
+								reverse_opinion = { who = FROM value = 40 }
 							}
 						}
 					}
 					AND = {
 						leads_faction = faction_succ_feudal_elective
-						liege = { 
+						PREV = { 
 							current_heir = {
-								reverse_opinion = { who = FROM value = 75 }
+								reverse_opinion = { who = FROM value = 50 }
 							}
 						}
 					}
@@ -2040,12 +2049,16 @@ faction_succ_feudal_elective = {
 			NOT = { FROM = { opinion = { who = LIEGE value = 0 } } }
 		}
 		modifier = {
-			factor = 2.0
-			NOT = { FROM = { opinion = { who = LIEGE value = -50 } } }
+			factor = 1.5
+			NOT = { FROM = { opinion = { who = LIEGE value = -40 } } }
+		}
+		modifier = {
+			factor = 1.5
+			NOT = { FROM = { opinion = { who = LIEGE value = -60 } } }
 		}
 		modifier = {
 			factor = 4.0
-			NOT = { FROM = { opinion = { who = LIEGE value = -75 } } }
+			NOT = { FROM = { opinion = { who = LIEGE value = -80 } } }
 		}
 		
 		modifier = {
@@ -2086,12 +2099,12 @@ faction_succ_feudal_elective = {
 			FROM = { trait = honest }
 		}
 		modifier = {
-			factor = 0.75
-			FROM = { trait = humble }
+			factor = 0.5
+			FROM = { trait = just }
 		}
 		modifier = {
 			factor = 0.75
-			FROM = { trait = just }
+			FROM = { trait = humble }
 		}
 		modifier = {
 			factor = 1.5
@@ -2106,20 +2119,12 @@ faction_succ_feudal_elective = {
 			FROM = { trait = arbitrary }
 		}
 		modifier = {
+			factor = 1.5
+			FROM = { trait = deceitful }
+		}
+		modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = greedy }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = impaler }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = deceitful }
 		}
 		modifier = {
 			factor = 4.0
@@ -2138,7 +2143,7 @@ faction_succ_feudal_elective = {
 					who = LIEGE
 					modifier = opinion_coerced_into_leaving_faction
 				}
-				opinion = { who = LIEGE value = -25 }
+				opinion = { who = LIEGE value = -40 }
 			}
 		}
 	}
@@ -2152,6 +2157,7 @@ faction_succ_feudal_elective = {
 			OR = {
 				prisoner = yes
 				trait = incapable
+				has_regent = yes
 				is_adult = no
 				is_landed = no
 				preparing_invasion = yes
@@ -2163,6 +2169,25 @@ faction_succ_feudal_elective = {
 			FROMFROM = {
 				current_heir = {
 					character = ROOT
+				}
+			}
+		}
+		
+
+		modifier = {
+			factor = 0
+			FROMFROM = {
+				holder_scope = {
+					any_spouse = { character = ROOT }
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			FROMFROM = {
+				current_heir = {
+					any_spouse = { character = ROOT }
 				}
 			}
 		}
@@ -2179,6 +2204,11 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0
 			
+			# FIXME: why are these in here (for faction_succ_feudal_elective)?
+			# the faction leader isn't even guaranteed to hold an elector title,
+			# let alone be eligible for succession, what the faction aims to
+			# accomplish.
+			
 			OR = {
 				AND = {
 					NOT = { in_faction = faction_succ_feudal_elective }
@@ -2194,16 +2224,19 @@ faction_succ_feudal_elective = {
 					opinion_diff = {
 						first = LIEGE
 						second = FROM
-						value = 25
+						value = 20
 						as_if_liege = yes
 					}
 				}
 			}
 			
-			NOT = {	
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
+			NOT = {
+				AND = {
+					has_opinion_modifier = {
+						who = FROM
+						modifier = opinion_coerced_into_joining_faction
+					}
+					opinion = { who = FROM value = 0 }
 				}
 			}
 		}
@@ -2213,17 +2246,20 @@ faction_succ_feudal_elective = {
 			OR = {
 				AND = {
 					NOT = { in_faction = faction_succ_feudal_elective }
-					opinion = { who = LIEGE value = 50 } 
+					opinion = { who = LIEGE value = 40 } 
 				}
 				AND = {
 					in_faction = faction_succ_feudal_elective
-					opinion = { who = LIEGE value = 75 } 
+					opinion = { who = LIEGE value = 50 } 
 				}
 			}
-			NOT = {	
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
+			NOT = {
+				AND = {
+					has_opinion_modifier = {
+						who = FROM
+						modifier = opinion_coerced_into_joining_faction
+					}
+					opinion = { who = FROM value = 0 }
 				}
 			}
 		}
@@ -2233,25 +2269,28 @@ faction_succ_feudal_elective = {
 			OR = {
 				AND = {
 					NOT = { in_faction = faction_succ_feudal_elective }
-					liege = { 
+					FROMFROM = { 
+						current_heir = {
+							reverse_opinion = { who = ROOT value = 40 }
+						}
+					}
+				}
+				AND = {
+					in_faction = faction_succ_feudal_elective
+					FROMFROM = { 
 						current_heir = {
 							reverse_opinion = { who = ROOT value = 50 }
 						}
 					}
 				}
-				AND = {
-					in_faction = faction_succ_feudal_elective
-					liege = { 
-						current_heir = {
-							reverse_opinion = { who = ROOT value = 75 }
-						}
-					}
-				}
 			}
-			NOT = {	
-				has_opinion_modifier = {
-					who = FROM
-					modifier = opinion_coerced_into_joining_faction
+			NOT = {
+				AND = {
+					has_opinion_modifier = {
+						who = FROM
+						modifier = opinion_coerced_into_joining_faction
+					}
+					opinion = { who = FROM value = 0 }
 				}
 			}
 		}
@@ -2280,8 +2319,18 @@ faction_succ_feudal_elective = {
 		}
 		
 		modifier = {
+			factor = 0.75
+			opinion = { who = LIEGE value = 10 }
+		}
+		
+		modifier = {
 			factor = 0.5
-			opinion = { who = LIEGE value = 25 } 
+			opinion = { who = LIEGE value = 20 } 
+		}
+		
+		modifier = {
+			factor = 0.5
+			opinion = { who = LIEGE value = 35 } 
 		}
 		
 		modifier = {
@@ -2290,10 +2339,15 @@ faction_succ_feudal_elective = {
 				who = FROM
 				modifier = opinion_coerced_into_joining_faction
 			}
+			opinion = { who = FROM value = 0 }
 		}
 		
 		modifier = {
 			factor = 2.0
+			# FIXME: again, a weird modifier for feudal elective, but at least in this
+			# case, it's a fairly dramatic difference in opinion between liege and the
+			# faction leader, so one could make a 'roleplaying' argument for more
+			# likelihood of following the faction leader rather than the liege.
 			opinion_diff = {
 				first = FROM
 				second = LIEGE
@@ -2335,12 +2389,12 @@ faction_succ_feudal_elective = {
 			trait = honest
 		}
 		modifier = {
-			factor = 0.75
-			trait = humble
+			factor = 0.5
+			trait = just
 		}
 		modifier = {
 			factor = 0.75
-			trait = just
+			trait = humble
 		}
 		modifier = {
 			factor = 1.5
@@ -2355,20 +2409,12 @@ faction_succ_feudal_elective = {
 			trait = arbitrary
 		}
 		modifier = {
+			factor = 1.5
+			trait = deceitful
+		}
+		modifier = {
 			factor = 2.0
 			trait = envious
-		}
-		modifier = {
-			factor = 2.0
-			trait = greedy
-		}
-		modifier = {
-			factor = 2.0
-			trait = impaler
-		}
-		modifier = {
-			factor = 2.0
-			trait = deceitful
 		}
 		modifier = {
 			factor = 4.0
@@ -2376,7 +2422,14 @@ faction_succ_feudal_elective = {
 		}
 		#Slow it down a bit
 		modifier = {
-			factor = 0.5
+			factor = 0.35 # it may take just under 3 years (vs. 2) for all members to join that possibly
+			              # will, except for some with reasonably acceptable opinions of the liege, which
+						  # could possibly take longer.  hence, the ultimatums have been slowed to wait
+						  # for higher faction power as well.  this will at least make an elective faction
+						  # revolt more easy to dissuade, more expected, and less subject to transient
+						  # conditions which affect its membership, such as the current heir to their
+						  # succ_law_title being a not-quite-of-age child, duchies not being created
+						  # and granted appropriately, de jure transfers not done yet, etc.
 		}
 		modifier = {
 			factor = 0
@@ -2388,7 +2441,7 @@ faction_succ_feudal_elective = {
 				who = LIEGE
 				modifier = opinion_coerced_into_leaving_faction
 			}
-			opinion = { who = LIEGE value = -25 }
+			opinion = { who = LIEGE value = -40 }
 		}
 	}
 	
@@ -3349,7 +3402,7 @@ faction_claimant = {
 			OR = {
 				is_female = no
 				AND = {
-					NOT = { religion_group = muslim } 
+					NOT = { religion_group = muslim }
 					NOT = { ROOT = { succ_law_title = { has_law = agnatic_succession } } }
 				}
 			}

--- a/ProjectBalance/decisions/faction_decisions.txt
+++ b/ProjectBalance/decisions/faction_decisions.txt
@@ -226,6 +226,7 @@ plot_decisions = {
 		allow = {
 			war = no
 			prisoner = no
+			has_regent = no
 			liege = {
 				NOT = { war_with = ROOT }
 				NOT = { reverse_has_truce = ROOT }
@@ -273,7 +274,18 @@ plot_decisions = {
 			}
 			
 			modifier = {
-				factor = 0.4 # Slow it down a bit
+				factor = 0.2
+				NOT = { 
+					faction_power = 
+					{
+						faction = faction_succ_feudal_elective
+						power = 1.35
+					}
+				}
+			}
+			
+			modifier = {
+				factor = 0.2 # Slow it down a bit
 			}
 			
 			modifier = {

--- a/ProjectBalance/decisions/faction_decisions.txt
+++ b/ProjectBalance/decisions/faction_decisions.txt
@@ -285,7 +285,7 @@ plot_decisions = {
 			}
 			
 			modifier = {
-				factor = 0.2 # Slow it down a bit
+				factor = 0.25 # Slow it down a bit
 			}
 			
 			modifier = {

--- a/ProjectBalance/decisions/faction_decisions.txt
+++ b/ProjectBalance/decisions/faction_decisions.txt
@@ -70,6 +70,21 @@ plot_decisions = {
 					any_war = {
 						OR = {
 							AND = {
+								# Notice how PREV is apparently used when PREVPREV
+								# should be used, clearly. Yet, zijistark constructed
+								# a whole, rigorous test case in-game exercising this
+								# usage, and using PREV vs. PREVPREV appears to be
+								# indistinguishable.  In other words, serious magic
+								# is going-on, or the 'character' command also takes
+								# a war scope and matches against any participant
+								# referenced in the war object (or remembers whether
+								# its enclosing scope was 'defender' or 'attacker'
+								# or potentially 'any_attacker' and so on).  I can't
+								# see a reason to 'fix' the vanilla usage; I assume
+								# this is some kind of hack that was added for war
+								# scopes when much fewer levels of PREV (e.g., no
+								# PREVPREV) were supported by the game.
+								
 								defender = { character = PREV }
 								NOT = { using_cb = depose_liege }
 								NOT = { using_cb = overthrow_ruler }
@@ -82,6 +97,8 @@ plot_decisions = {
 								OR = {
 									using_cb = invasion
 									using_cb = religious
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = tribal_invasion
 									using_cb = muslim_invasion
 									using_cb = viking_invasion
@@ -178,6 +195,8 @@ plot_decisions = {
 								OR = {
 									using_cb = invasion
 									using_cb = religious
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = tribal_invasion
 									using_cb = muslim_invasion
 									using_cb = viking_invasion
@@ -275,6 +294,8 @@ plot_decisions = {
 								OR = {
 									using_cb = invasion
 									using_cb = religious
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = tribal_invasion
 									using_cb = muslim_invasion
 									using_cb = viking_invasion
@@ -371,6 +392,8 @@ plot_decisions = {
 								OR = {
 									using_cb = invasion
 									using_cb = religious
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = tribal_invasion
 									using_cb = muslim_invasion
 									using_cb = viking_invasion
@@ -490,6 +513,8 @@ plot_decisions = {
 							AND = {
 								defender = { character = PREV }
 								OR = {
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = religious
 									using_cb = muslim_invasion
 									using_cb = viking_invasion
@@ -755,6 +780,8 @@ plot_decisions = {
 								}
 								OR = {
 									using_cb = religious
+									using_cb = retake_religious_lands
+									using_cb = special_holy_war
 									using_cb = crusade
 									using_cb = muslim_invasion
 									using_cb = viking_invasion

--- a/ProjectBalance/decisions/faction_decisions.txt
+++ b/ProjectBalance/decisions/faction_decisions.txt
@@ -274,7 +274,7 @@ plot_decisions = {
 			}
 			
 			modifier = {
-				factor = 0.2
+				factor = 0.5
 				NOT = { 
 					faction_power = 
 					{
@@ -285,7 +285,7 @@ plot_decisions = {
 			}
 			
 			modifier = {
-				factor = 0.25 # Slow it down a bit
+				factor = 0.3 # Slow it down a bit
 			}
 			
 			modifier = {


### PR DESCRIPTION
- Regular factions (non-autonomy) will now now wait to submit a revolt ultimatum until after their liege is no longer using ANY of the 3 holy war CBs in PB
- Moderate nerf of the feudal elective faction. It is generally more tolerant than the other succession factions, more easily dissuaded/coerced, less subject to transient issues which will definitely be solved-- at least by the AI-- in due time, and generally slower to jump to an ultimatum
- AI realms must be at true min. CA to qualify for the elective faction (crown_levies_1 was previously allowed).  Player realms still qualify for the elective faction with min. CA except for crown_levies_1, as previously
- Testing shows that it's quite possible, e.g., for an AI France to avoid an overwhelming elective faction revolt within 5 years of the 1066 start (previously a problem) but that the faction still remains a threat in such scenarios
- In general, in combination with the CA revocation cooldown, this should slow down the currently-rampant ahistorical AI realm degeneration into elective
