### PR TITLE
AF improvements

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -15,7 +15,9 @@
 	Various minor bugfixes for the autonomy faction [zijistark]
 	Successful faction revolts that revoke crown laws no longer "use-up" the liege's once-in-a-lifetime right to change a crown law, if he/she hadn't already changed one beforehand. This was already the case for some faction revolts and is now consistent [zijistark]
 	Regular factions (non-autonomy) will now now wait to submit a revolt ultimatum until after their liege is no longer using ANY of the 3 holy war CBs in PB [zijistark]
-	Moderate nerf of the feudal elective faction. The faction is generally more tolerant than the other succession law factions, more easily dissuaded/coerced, less subject to transient issues which will definitely be solved, at least by the AI, in due time, and generally slower to jump to an ultimatum. Testing shows that it's quite possible, e.g., for an AI France to avoid an overwhelming elective faction revolt within 5 years of the 1066 start (previously a problem) but that the faction still remains a threat in those scenarios [zijistark]
+	Moderate nerf of the feudal elective faction. The faction is generally more tolerant than the other succession law factions, more easily dissuaded/coerced, less subject to transient issues which will definitely be solved-- at least by the AI-- in due time, and generally slower to jump to an ultimatum. Testing shows that it's quite possible, e.g., for an AI France to avoid an overwhelming elective faction revolt within 5 years of the 1066 start (previously a problem) but that the faction still remains a threat in those scenarios [zijistark]
+	Autonomy faction event text overhauled to add flavor and be read from a first-person perspective like other CKII events [zijistark]
+	Autonomy faction now highly unlikely to call a meeting while their liege is in the middle of a large-scale offensive war such as a crusade, invasion, or holy war; actual tolerated delay and chance of a meeting being called anyway past a certain point vary by the war's casus belli [zijistark]
 
 3.4.1
 	Updated the implementation of the New Duel Engine to its latest version

--- a/ProjectBalance/common/cb_types/ProjectBalance.txt
+++ b/ProjectBalance/common/cb_types/ProjectBalance.txt
@@ -6,6 +6,8 @@ remove_internal_peace = {
 	truce_days = 3650
 	can_call_allies = no
 	can_ask_to_join_war = no
+	is_revolt_cb = yes
+	major_revolt = yes
 	
 	can_use = {
 		FROM = {
@@ -143,6 +145,8 @@ remove_revokation = {
 	truce_days = 3650
 	can_call_allies = no
 	can_ask_to_join_war = no
+	is_revolt_cb = yes
+	major_revolt = yes
 	
 	can_use = {
 		FROM = {
@@ -277,6 +281,8 @@ remove_inheritance = {
 	truce_days = 3650
 	can_call_allies = no
 	can_ask_to_join_war = no
+	is_revolt_cb = yes
+	major_revolt = yes
 	
 	can_use = {
 		FROM = {
@@ -402,6 +408,8 @@ reduce_crown_levies = {
 	truce_days = 3650
 	can_call_allies = no
 	can_ask_to_join_war = no
+	is_revolt_cb = yes
+	major_revolt = yes
 	
 	can_use = {
 		ROOT = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -47,11 +47,22 @@ character_event = {
 			trait = deceitful
 			trait = greedy
 			NOT = { opinion = { who = LIEGE value = 0 } }
-			crownlaw_title = { has_law = king_peace_2 }
-			crownlaw_title = { has_law = emperor_peace_2 }
-			crownlaw_title = { has_law = revokation_2 }
-			tier = duke
-			tier = king
+			liege = {
+				ROOT = {
+					crownlaw_title = {
+						AND = {
+							holder_scope = { character = PREVPREVPREV }
+							OR = {
+								has_law = king_peace_2
+								has_law = emperor_peace_2
+								has_law = revokation_2
+								has_law = inheritance_1
+							}
+						}
+					}
+				}
+			}
+			higher_tier_than = count
 		}
 	}
 	option = {
@@ -374,7 +385,7 @@ character_event = {
 			}
 		}
 		modifier = {
-			factor = 10 # not too much delay as time passes, never getting past the end of the 7 year threshold
+			factor = 10 # not too much delay as time passes, never getting past the normal 7 year threshold
 			liege = {
 				any_war = {
 					attacker = { character = PREVPREV }

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -274,8 +274,32 @@ character_event = {
 	border = GFX_event_normal_frame_religion
 	
 	trigger = {
-		NOT = {
-			liege = { has_character_flag = autonomy_faction_revolt }
+		liege = {
+			NOT = {
+
+				# TODO: autonomy_faction_revolt state should be obsoleted or kept in
+				# a hidden, inherited character modifier for robustness against liege
+				# changes.
+				
+				has_character_flag = autonomy_faction_revolt
+
+				any_war = {
+					# electing to not use the weird single-PREV usage of vanilla in, e.g., faction_decisions.
+					# apparently, it works either way from my testing, so might as well go with the logical
+					# option (the `character' trigger is otherwise given a war scope target-- weird, right?)
+					defender = { character = PREVPREV }
+					OR = {
+						# the liege's revolt flag should cover these [most], so long as the liege didn't change.
+						# explicitly checking can only help, though.
+						
+						using_cb = remove_internal_peace
+						using_cb = remove_revokation
+						using_cb = remove_inheritance
+						using_cb = reduce_crown_levies
+						using_cb = depose_liege
+					}
+				}
+			}
 		}
 		leads_faction = faction_autonomy
 		OR = {
@@ -299,12 +323,70 @@ character_event = {
 			has_character_flag = faction_meeting
 		}
 		modifier = {
+			factor = 0.1 # allow conditional delays up to 3 more years (10yr)
+			had_character_flag = { flag = faction_meeting days = 3650 }
+			has_character_flag = faction_meeting
+		}
+		modifier = {
 			factor = 2 #Slow it down if an ultimatum has recently been accepted
 			has_opinion_modifier = { who = LIEGE modifier = opinion_accepted_ultimatum }
 		}
 		modifier = {
 			factor = 0.5
 			NOT = { has_character_flag = faction_meeting }
+		}
+		modifier = {
+			factor = 1000 # balances the final 7yr soft limit and otherwise roughly overrides until 10yr
+			liege = {
+				OR = {
+					any_war = {
+						any_attacker = { character = PREVPREV }
+						using_cb = crusade
+						
+						# there is currently no autonomy faction outcome to help the liege (when happy, which we
+						# don't even know yet) as a crusade participant, so this just makes it very unlikely for
+						# popups and potential ultimatums to be launched while participating in an offensive crusade.
+						# eco/mil cooperation renewal, if currently relevant, can wait too.  faction meetings during
+						# crusades are a bit immersion-breaking.  NOTE: delay during such a war will likely result in
+						# a faction meeting shortly after the war is over.
+					}
+					
+					any_war = {
+						attacker = { character = PREVPREV }
+						# likewise logic for the following ongoing, large-scale offensive wars:
+						
+						OR = {
+							using_cb = invasion
+							using_cb = viking_invasion
+							using_cb = tribal_invasion
+							using_cb = muslim_invasion
+							
+							# a [incomplete] way to delay faction meetings while their liege is probably pushing
+							# a claim for a member.  we *should* also check the thirdparty_title's claimants for
+							# faction member match or scope to the thirdparty character (not sure how to do that
+							# off the top of my head at the moment) from this war scope and ensure it is a faction
+							# member (or vassal thereof) whose claim is being pressed.  for AI behavior, this
+							# trigger alone covers it in at least 99% of cases, though.
+							using_cb = other_claim
+						}
+					}
+				}
+			}
+		}
+		modifier = {
+			factor = 10 # not too much delay as time passes, never getting past the end of the 7 year threshold
+			liege = {
+				any_war = {
+					attacker = { character = PREVPREV }
+					
+					OR = {
+						# likewise logic (can't help the liege, shouldn't hurt the liege) for the following:
+						using_cb = religious
+						using_cb = retake_religious_lands
+						using_cb = special_holy_war
+					}
+				}
+			}
 		}
 	}
 	option = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -42,12 +42,8 @@ character_event = {
 				crownlaw_title = {
 					OR = {
 						NOT = { holder_scope = { character = PREVPREVPREV } }
-						succ_law_title = {
-							OR = {
-								current_heir = { NOT = { character = ROOT } }
-								has_law = succ_feudal_elective
-							}
-						}
+						current_heir = { NOT = { character = ROOT } }
+						has_law = succ_feudal_elective
 					}
 				}
 			}
@@ -101,7 +97,16 @@ character_event = {
 			change_variable = { which = "autonomy_desire" value = -5 }
 		}
 		if = {
-			limit = { liege = { current_heir = { character = ROOT } } } # (only applies to feudal elective)
+			limit = {
+				liege = {
+					ROOT = {
+						crownlaw_title = {
+							holder_scope = { character = PREVPREVPREV }
+							current_heir = { character = ROOT }
+						}
+					}
+				}
+			}
 			change_variable = { which = "autonomy_desire" value = -5 }
 		}
 		if = {
@@ -326,6 +331,7 @@ character_event = {
 		}
 		leads_faction = faction_autonomy
 		OR = {
+			has_character_flag = forced_faction_meeting # special flag to programmatically force meeting timing
 			NOT = { has_character_flag = faction_meeting }
 			had_character_flag = { flag = faction_meeting days = 1095 }
 		}
@@ -411,6 +417,9 @@ character_event = {
 				}
 			}
 		}
+	}
+	immediate = {
+		clr_character_flag = forced_faction_meeting
 	}
 	option = {
 		name = OK
@@ -923,6 +932,7 @@ character_event = {
 			check_variable = { which = "autonomy_mood" value = 0 }
 		}
 		name = meneth.221.a
+		clr_character_flag = force_faction_happy
 		character_event = { id = meneth.250 } #What action to take
 		liege = { character_event = { id = meneth.253 } } #Notify liege positive
 		ai_chance = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -932,7 +932,6 @@ character_event = {
 			check_variable = { which = "autonomy_mood" value = 0 }
 		}
 		name = meneth.221.a
-		clr_character_flag = force_faction_happy
 		character_event = { id = meneth.250 } #What action to take
 		liege = { character_event = { id = meneth.253 } } #Notify liege positive
 		ai_chance = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -13,6 +13,8 @@ character_event = {
 	picture = GFX_evt_battle
 	border = GFX_event_normal_frame_religion
 	
+	only_rulers = yes
+	
 	trigger = {
 		NOT = { has_character_flag = desires_autonomy }
 		ai = yes
@@ -25,19 +27,29 @@ character_event = {
 		}
 		liege = {
 			is_feudal = yes
-			OR = {
-				current_heir = { NOT = { character = ROOT } }
-				has_law = succ_feudal_elective
-			}
-			OR = {
-				tier = king
-				tier = emperor
-			}
+			higher_tier_than = duke
 			OR = { #Ensures someone at least moderately strong creates the faction
 				any_vassal = { leads_faction = faction_autonomy }
 				ROOT = { tier = duke }
 				ROOT = { tier = king }
 				NOT = { any_vassal = { tier = duke } }
+			}
+			
+			# properly allow for gavelkind or any other decentralized succession laws as well as ensure that
+			# vassals that are affected by a foreign crown law title will favor autonomy, regardless of
+			# whether they are the current heir to that title
+			ROOT = {
+				crownlaw_title = {
+					OR = {
+						NOT = { holder_scope = { character = PREVPREVPREV } }
+						succ_law_title = {
+							OR = {
+								current_heir = { NOT = { character = ROOT } }
+								has_law = succ_feudal_elective
+							}
+						}
+					}
+				}
 			}
 		}
 		#Character needs some reason to join
@@ -50,7 +62,7 @@ character_event = {
 			liege = {
 				ROOT = {
 					crownlaw_title = {
-						AND = {
+						AND = { # make sure the liege actually holds the title with CA
 							holder_scope = { character = PREVPREVPREV }
 							OR = {
 								has_law = king_peace_2

--- a/ProjectBalance/localisation/PB_events.csv
+++ b/ProjectBalance/localisation/PB_events.csv
@@ -37,30 +37,30 @@ meneth.214.desc;[From.GetTitledFirstName] has agreed to release [FromFrom.GetTit
 meneth.215.desc;[From.GetTitledFirstName] has not agreed to release [FromFrom.GetTitledFirstName].;;;;;;;;;;;;;x
 meneth.217.desc;The laws of your realm prevent you from instituting anything but minimal obligations from your vassals. Your demesne laws have therefore been returned to minimum.;;;;;;;;;;;;;x
 meneth.219.desc;It is time for a faction meeting. We will determine what action to take, if any, once we know how everyone feels about our liege's rule.;;;;;;;;;;;;;x
-meneth.220.desc;A faction meeting has begun, and the first point on the agenda is determining how the faction as a whole feels about our liege's rule. What is your opinion of their rule?;;;;;;;;;;;;;x
-meneth.220.a;Their rule is just;;;;;;;;;;;;;x
+meneth.220.desc;A faction meeting has begun, and the first point on the agenda is to determine how the faction as a whole feels about [Root.Liege.GetTitledFirstName]'s rule. What is your opinion?;;;;;;;;;;;;;x
+meneth.220.a;Overall, I'm pleased with [Root.Liege.GetHerHis] rule;;;;;;;;;;;;;x
 meneth.220.b;No opinion;;;;;;;;;;;;;x
-meneth.220.c;Inustices must be righted;;;;;;;;;;;;;x
+meneth.220.c;[Root.Liege.GetTitledFirstName] must right some injustice;;;;;;;;;;;;;x
 meneth.221.desc;Based on the faction vote, the following options are available to us. What action should we take? Your choice will be put to a vote.;;;;;;;;;;;;;x
 meneth.221.a;Support our liege;;;;;;;;;;;;;x
 meneth.221.b;Strengthen our position;;;;;;;;;;;;;x
 meneth.221.c;Demand crown authority reduced;;;;;;;;;;;;;x
 meneth.221.d;Weaken liege;;;;;;;;;;;;;x
-meneth.222.desc;A vote has been called on whether or not to provide our liege with financial support for his current war. It is proposed that we all give up a tenth of our income this year to fund the war. Do you support this?;;;;;;;;;;;;;x
+meneth.222.desc;A vote has been called on whether or not to provide [Root.Liege.GetTitledFirstName] with financial support for the current war. The proposal is to contribute a tenth of our income this year to fund [Root.Liege.GetHerHim]. Do you support this?;;;;;;;;;;;;;x
 meneth.223.desc;All the votes have been tallied.;;;;;;;;;;;;;x
 meneth.223.a;The vote succeeded;;;;;;;;;;;;;x
 meneth.223.b;The vote failed;;;;;;;;;;;;;x
 meneth.224.desc;All the votes have been tallied. The vote succeeded;;;;;;;;;;;;;x
 meneth.225.desc;All the votes have been tallied. The vote failed;;;;;;;;;;;;;x
-meneth.226.desc;Our vassals have decided to provide us with financial support in our current war.;;;;;;;;;;;;;x
-meneth.227.desc;A vote has been called on whether or not to demand lower obligations. It is proposed that we present our liege with an ultimatum. Do you support this?;;;;;;;;;;;;;x
-meneth.228.desc;Our vassals demand that we lower their obligations. Should we do this?;;;;;;;;;;;;;x
-meneth.229.desc;A vote has been called on whether or not to demand title revocation removed. It is proposed that we present our liege with an ultimatum. Do you support this?;;;;;;;;;;;;;x
-meneth.230.desc;Our vassals demand that we get rid of title revocation. Should we do this?;;;;;;;;;;;;;x
-meneth.231.desc;A vote has been called on whether or not to demand internal peace removed. It is proposed that we present our liege with an ultimatum. Do you support this?;;;;;;;;;;;;;x
-meneth.232.desc;Our vassals demand that we get rid of internal peace. Should we do this?;;;;;;;;;;;;;x
-meneth.233.desc;Our liege has refused our ultimatum! Should we call for open revolt?;;;;;;;;;;;;;x
-meneth.234.desc;Our liege has refused our ultimatum, and the faction leader is calling for an open revolt! Is revolt the right choice?;;;;;;;;;;;;;x
+meneth.226.desc;My loyal vassals have decided to provide me with financial support for the current war. Perhaps this will tip the scales in our favor.;;;;;;;;;;;;;x
+meneth.227.desc;A vote has been called upon whether to demand lower vassal obligations. It is proposed that we present [Root.Liege.GetTitledFirstName] with an ultimatum. Do you support this?;;;;;;;;;;;;;x
+meneth.228.desc;It seems that my vassals are unhappy with their current level of obligations. They're demanding that I change the law. Should I accept the ultimatum?;;;;;;;;;;;;;x
+meneth.229.desc;A vote has been called upon whether to demand title revocation removed. It is proposed that we present [Root.Liege.GetTitledFirstName] with an ultimatum. Do you support this?;;;;;;;;;;;;;x
+meneth.230.desc;As usual, my vassals are complaining about the title revocation law. This time, however, they've served their complaints to me along with an actual ultimatum. Do I sacrifice the law? I potentially face a dangerous revolt if I do not.;;;;;;;;;;;;;x
+meneth.231.desc;A vote has been called on whether to demand revocation of the internal peace law. It is proposed that we present [Root.Liege.GetTitledFirstName] with an ultimatum. Do you support this?;;;;;;;;;;;;;x
+meneth.232.desc;A confluence of my vassals demand that I revoke a law of the land, allowing vassal war and infighting. What should I do?;;;;;;;;;;;;;x
+meneth.233.desc;[Root.Liege.GetTitledFirstName] has refused our ultimatum! Should we call for open revolt?;;;;;;;;;;;;;x
+meneth.234.desc;[Root.Liege.GetTitledFirstName] has refused our ultimatum, and the faction leader is calling for an open revolt! Is revolt the right choice?;;;;;;;;;;;;;x
 meneth.235.desc;The votes have been tallied.;;;;;;;;;;;;;x
 meneth.235.a;To war!;;;;;;;;;;;;;x
 meneth.235.b;Peace in our time;;;;;;;;;;;;;x
@@ -68,47 +68,47 @@ meneth.236.desc;We have decided to call a vote for the reduction of crown author
 meneth.236.a;Lower obligations;;;;;;;;;;;;;x
 meneth.236.b;No revocation;;;;;;;;;;;;;x
 meneth.236.c;No internal peace;;;;;;;;;;;;;x
-meneth.237.desc;We have decided to call a vote to weaken our liege. How should he be weakened?;;;;;;;;;;;;;x
+meneth.237.desc;We have decided to call a vote to weaken our liege. How should [Root.Liege.GetSheHe] be weakened?;;;;;;;;;;;;;x
 meneth.237.a;Force release of imprisoned vassals;;;;;;;;;;;;;x
 meneth.237.b;Give away a county;;;;;;;;;;;;;x
-meneth.237.c;Give money to faction;;;;;;;;;;;;;x
-meneth.237.d;Abdicate;;;;;;;;;;;;;x
-meneth.238.desc;The faction leader wants our liege to release all vassals currently held prisoner. Do you support this?;;;;;;;;;;;;;x
-meneth.239.desc;Our vassals demand that we release all vassals currently held prisoner. Should we do this?;;;;;;;;;;;;;x
-meneth.240.desc;The faction leader wants our liege to give away a county. Do you support this?;;;;;;;;;;;;;x
-meneth.241.desc;Our vassals demand that we give away a county. Should we do this?;;;;;;;;;;;;;x
-meneth.242.desc;The faction leader wants our liege to give all faction members money. Do you support this?;;;;;;;;;;;;;x
-meneth.243.desc;Our vassals demand that we give them money. Should we do this?;;;;;;;;;;;;;x
-meneth.244.desc;The faction leader wants our liege to allow external inheritance. Do you support this?;;;;;;;;;;;;;x
-meneth.245.desc;Our vassals demand that we allow external inheritance. Should we do this?;;;;;;;;;;;;;x
-meneth.246.desc;The faction leader wants our liege to abdicate. Do you support this?;;;;;;;;;;;;;x
-meneth.247.desc;Our vassals demand that we abdicate. Should we do this?;;;;;;;;;;;;;x
-meneth.248.desc;We have decided to take an action that won't hurt nor harm our liege. What action should we take?;;;;;;;;;;;;;x
-meneth.248.a;Preserve status quo;;;;;;;;;;;;;x
-meneth.248.b;Military cooperation;;;;;;;;;;;;;x
-meneth.248.c;Economic cooperation;;;;;;;;;;;;;x
+meneth.237.c;Give money to the faction;;;;;;;;;;;;;x
+meneth.237.d;[Root.Liege.GetSheHeCap] should bloody abdicate!;;;;;;;;;;;;;x
+meneth.238.desc;The faction leader wants [Root.Liege.GetTitledFirstName] to release all vassals currently held prisoner. Do you support this?;;;;;;;;;;;;;x
+meneth.239.desc;The autonomy faction demands that I release all vassals currently held prisoner. It could be worse.;;;;;;;;;;;;;x
+meneth.240.desc;The faction leader wants our liege, [Root.Liege.GetTitledFirstName], to give away a county. Do you support this?;;;;;;;;;;;;;x
+meneth.241.desc;My greedy vassals demand that I just give away one of the counties in my demesne! Shall I cave?;;;;;;;;;;;;;x
+meneth.242.desc;The faction leader wants our liege to send all of the faction's members an appropriate amount of gold and silver. Do you support this?;;;;;;;;;;;;;x
+meneth.243.desc;My avaricious underlings have gotten the courage to demand that I give them gold as reparations for whatever wrong they imagine me to have done them. Should I do this?;;;;;;;;;;;;;x
+meneth.244.desc;The faction leader wants [Root.Liege.GetTitledFirstName] to allow external inheritance. Do you support this?;;;;;;;;;;;;;x
+meneth.245.desc;Most of my vassals demand that I change crown law in order to allow them to inherit titles external to the realm, something which may consequently allow them to leave my realm, taking a piece of it with them when they do. Should I do it?;;;;;;;;;;;;;x
+meneth.246.desc;The faction leader wants [Root.Liege.GetTitledFirstName] to abdicate from his position as our liege lord. Do you support deposing [Root.Liege.GetHerHim]?;;;;;;;;;;;;;x
+meneth.247.desc;By [Root.Religion.GetRandomGodNameCap], I'd never thought it would come to this. A dissident, powerful faction of my vassals has voted to demand my abdication as their rightful liege lord. Should I humbly accept the ultimatum? If not, I'll risk allowing the realm to be torn apart by revolt.;;;;;;;;;;;;;x
+meneth.248.desc;We have decided to take an action that will neither hurt nor harm our liege. What action should we take?;;;;;;;;;;;;;x
+meneth.248.a;Preserve the status quo;;;;;;;;;;;;;x
+meneth.248.b;Share military supplies and leadership, boosting our levies;;;;;;;;;;;;;x
+meneth.248.c;Cooperate in economic development endeavors;;;;;;;;;;;;;x
 meneth.249.desc;The faction leader has called for increased cooperation between faction members. This can only be good.;;;;;;;;;;;;;x
 meneth.249.a;Military cooperation begins;;;;;;;;;;;;;x
 meneth.249.b;Economic cooperation begins;;;;;;;;;;;;;x
-meneth.250.desc;We have decided to support our liege. What action should we take?;;;;;;;;;;;;;x
-meneth.250.a;Provide financial support;;;;;;;;;;;;;x
-meneth.250.b;Give commendation;;;;;;;;;;;;;x
-meneth.251.desc;The faction leader wants to commend our liege for his good rule. Do you support this?;;;;;;;;;;;;;x
-meneth.252.desc;Our vassals have commended us for our good rule. Only good can come of this.;;;;;;;;;;;;;x
-meneth.253.desc;Many of our important vassals sent riders to let us know that they are meeting to discuss our rule, with all due respect to the law.  All in all, they seem to be happy with us. If anything comes of it, we will know within days.;;;;;;;;;;;;;x
-meneth.254.desc;Many of our vassals are holding a meeting, discussing their opinion of our rule. They're probably in favor the status quo.;;;;;;;;;;;;;x
-meneth.255.desc;A solid group of our vassals have been riding for days in order to meet, many openly criticizing our rule. Our spymaster, [Root.job_spymaster.GetBestName], reports that a number seem to be pretty disgruntled. If anything actually comes of the their complaining, we will know within days.;;;;;;;;;;;;;x
-meneth.256.desc;Our vassals have wisely decided not to act upon our refusal to heed their ultimatum. We should take notice that they might not be so forgiving in the future.;;;;;;;;;;;;;x
-meneth.257.desc;Many of our vassals have decided to cooperate in order to improve their own situation. While this has no direct effect upon us, it does make them a greater potential danger to our rule.;;;;;;;;;;;;;x
+meneth.250.desc;We have decided to support our liege, [Root.Liege.GetTitledFirstName]. What action should we take?;;;;;;;;;;;;;x
+meneth.250.a;Provide financial support for the current war;;;;;;;;;;;;;x
+meneth.250.b;Give [Root.Liege.GetHerHim] a commendation;;;;;;;;;;;;;x
+meneth.251.desc;The faction leader wants to commend our liege for the good job that [Root.Liege.GetSheHe]'s done ruling the realm while upholding our rights. Do you support this?;;;;;;;;;;;;;x
+meneth.252.desc;I have just received word that my vassals want to commend my rule of the realm as well as recognize my just protection of their rights and, indeed, the vassal contract. I'm not sure whether to accept with pride or only with the greatest humility, but either way, I will gladly receive their commendation with honor and gratitude.;;;;;;;;;;;;;x
+meneth.253.desc;Many of my important vassals sent riders to let us know that they are meeting to discuss my rule, with all due respect to the law. All in all, they seem happy. If anything comes of the meeting, I'll hear within days.;;;;;;;;;;;;;x
+meneth.254.desc;Many of my vassals are holding a meeting, one of the topics of which is the quality of my rule. They probably don't have any aims but the status quo, although they may decide to go forward with autonomous cooperation measures which have recently been proposed.;;;;;;;;;;;;;x
+meneth.255.desc;A solid group of my vassals have been riding for days in order to meet, many openly criticizing my rule. My spymaster, [Root.job_spymaster.GetBestName], reports that a number seem to be pretty disgruntled. If anything serious actually comes of the their complaining, I'll know within days.;;;;;;;;;;;;;x
+meneth.256.desc;My vassals have wisely decided not to act upon my refusal to heed their ultimatum. They might not be so quick to stand-down in the future.;;;;;;;;;;;;;x
+meneth.257.desc;Most of my vassals have decided to cooperate in order to improve their own situation. While this doesn't directly affect me, it does make them a greater potential danger to my rule. On the other hand, it may be easier to squeeze some extra coin or levies from them if the need should arise.;;;;;;;;;;;;;x
 meneth.257.a;They will be able to field more soldiers;;;;;;;;;;;;;x
 meneth.257.b;They'll cooperate in economic development;;;;;;;;;;;;;x
-meneth.258.desc;The result of the vote is that we are to revolt. If we have any second thoughts, now is the time to voice them. The war will be declared in three weeks. Note that as a player you'll have to leave the faction manually in order to stay loyal.;;;;;;;;;;;;;x
+meneth.258.desc;According to the tally, we are to revolt. If there are any second thoughts, now is the time to voice them. We intend to mobilize in three weeks. If you wish to stay loyal to [Root.Liege.GetTitledFirstName], in addition to voicing your opinion now, you MUST manually leave the autonomy faction before the war.;;;;;;;;;;;;;x
 meneth.258.a;To war!;;;;;;;;;;;;;x
-meneth.258.b;Remain loyal to our liege;;;;;;;;;;;;;x
-faction_members_angry; This will ruin our relations with everyone in the faction except those who also stay loyal to our liege.;;;;;;;;;;;;;x
-meneth.259.desc;The result of the vote is that there will be no revolt.;;;;;;;;;;;;;x
+meneth.258.b;I refuse to be a part of this petty revolt;;;;;;;;;;;;;x
+faction_members_angry;This will degrade relations with all faction members that do not also refuse the call to war.;;;;;;;;;;;;;x
+meneth.259.desc;The votes have all been counted, and we will not revolt.;;;;;;;;;;;;;x
 meneth.260.desc;It is time to launch our revolt!;;;;;;;;;;;;;x
-meneth.261.desc;Our vassals have decided to act upon our refusal to heed their ultimatum. We must prepare for war starting within a month.;;;;;;;;;;;;;x
+meneth.261.desc;It seems my vassals do indeed have the nerve to act upon my refusal to heed their outrageous ultimatum. I must prepare for war immediately: they'll be able to mobilize and march upon [Root.Capital.GetName] within the month. If blood is what they want, then blood is what they'll get.;;;;;;;;;;;;;x
 meneth.400.desc;It is time we asserted our dominion over Anatolia. We should invade Iconium.;;;;;;;;;;;;;x
 meneth.400.a;To war!;;;;;;;;;;;;;x
 meneth.400.b;I'd rather not;;;;;;;;;;;;;x


### PR DESCRIPTION
- Some small details addressed
- An AF localisation overhaul for first-person perspective, where appropriate, like other CKII events + much more variation in the various event texts and options + mild flavor + some clarifications
- A set of ongoing war checks which affects the trigger (only 1 case, for robustness) and MTTH (a couple cases of varying degree for which the faction is willing to delay-- for awhile longer, at least-- due to a large-scale offensive war or the liege pushing someone else's claim) of the faction meeting start event
- It is now possible to force a faction meeting to be called by event, regardless of when it was last called (but the other trigger conditions still apply)
- If you step on a crack, you'll fall and break your back
- PB's revolt CBs are now properly tagged as revolts/major_revolts so that the AI and various event triggers may act accordingly.  It's possible that this may have consequences which I have not foreseen, but I don't think so.
- Did enough testing to confirm no breakage and that the new localisation looks great, as did all the associated functionality (missed the happy cases, but I'm sure they're fine too)
