### PR TITLE
The morning merge

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,5 +1,6 @@
 3.4.3
 	Bugfix for Jewish players not being able to take loans via the decisions menu. AI Jews could still take loans [zijistark]
+	Autonomy faction is now guaranteed to not be created by the AI for 6 months after game startup. This allows a player vassal plenty of time to start the faction (i.e., be the leader) if they so desire. Ideally, the faction will become even more democratic in future releases, but the leader currently plays a pivotal role in setting the agenda of meetings [zijistark]
 
 3.4.2
 	Shattered Balance, No Ahistorical Empires, and Gender Equality can now be enabled in-game before first unpausing the game

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,3 +1,6 @@
+3.4.3
+	Bugfix for Jewish players not being able to take loans via the decisions menu. AI Jews could still take loans [zijistark]
+
 3.4.2
 	Shattered Balance, No Ahistorical Empires, and Gender Equality can now be enabled in-game before first unpausing the game
 	(PB+SWMH) Fixed three provinces in Ethiopia having no holdings

--- a/ProjectBalance/common/objectives/PB_factions.txt
+++ b/ProjectBalance/common/objectives/PB_factions.txt
@@ -38,8 +38,27 @@ faction_autonomy = {
 		}
 		modifier = {
 			factor = 0
+			current_heir = {
+				any_spouse = { character = FROM }
+			}
+		}
+		modifier = {
+			factor = 0
 			FROM = {
 				NOT = { has_character_flag = desires_autonomy }
+			}
+		}
+		modifier = {
+			factor = 0
+			FROM = {
+				# guarantee to player that AI won't create faction 'til 6mos since
+				# game startup, allowing them to assume the role of faction leader
+				# if they prefer.  leader may be a less important role in the future,
+				# but until then, player should get first-pick even if they forget
+				# before unpausing.
+				ai = yes
+				has_global_flag = project_balance
+				NOT = { had_global_flag = { flag = project_balance days = 180 } }
 			}
 		}
 		modifier = {

--- a/ProjectBalance/decisions/PB_loans.txt
+++ b/ProjectBalance/decisions/PB_loans.txt
@@ -6,6 +6,7 @@ decisions = {
 				religion_group = christian
 				religion_group = muslim
 				religion_group = zoroastrian_group
+				religion_group = jewish_group
 				has_character_flag = loan_decisions
 			}
 			OR = {

--- a/ProjectBalance/events/PB_factions.txt
+++ b/ProjectBalance/events/PB_factions.txt
@@ -107,7 +107,7 @@ character_event = {
 					}
 				}
 			}
-			change_variable = { which = "autonomy_desire" value = -5 }
+			change_variable = { which = "autonomy_desire" value = -10 }
 		}
 		if = {
 			limit = { NOT = { opinion = { who = LIEGE value = -10 } } }


### PR DESCRIPTION
Just miscellany, mainly:
- Jewish non-AI loan-taking fixed (potential of loan_decisions toggle didn't include jewish_group)
- Guarantee of 6 months following game start for player to decide whether to lead autonomy faction. I did this by simply halting the AI faction creation chance until 180 days had passed.  Since the choice is rather arbitrary anyway (aside from being more likely to not be a count when there are vassal dukes or kings around), we might as well give it to the player if eligible, should they want to take a more active role.  Ultimately, it'd be nice if the faction leader's bias didn't matter and agenda-setting was more direct, but the role matters a lot currently, and thus players might as well get the [guaranteed] choice of being faction leader if they want-- with all the risks that come with it.
