### PR TITLE
Depose Antipope CB, Install Anti-King faction CB, Anti-King faction from vanilla

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -7,6 +7,7 @@
 	Guardian events: fixed those that assume age of adulthood is 16 and that child was actually part of liege's court, increased likelihood of a good candidate for guardianship when vassals offer, increased delay before a vassal offers to mentor your newly-6-year-old child (fewer and less annoying popups), and so on
 	Ensured that the crusade target is always destroyed if it cannot be usurped and the war target holds the title
 	(PB+SWMH) Fixed there being no centers of trade
+	Ported depose_antipope and cb_install_antiking casus belli as well as the Anti-King Faction from vanilla
 
 3.4.2
 	Shattered Balance, No Ahistorical Empires, and Gender Equality can now be enabled in-game before first unpausing the game

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -9294,3 +9294,298 @@ depose_antipope = {
 		factor = 100
 	}
 }
+
+depose_antipope = {
+	name = CB_NAME_DEPOSE_ANTIPOPE
+	war_name = WAR_NAME_DEPOSE_ANTIPOPE
+	sprite = 11
+	truce_days = 3650
+	is_permanent = yes
+	can_ask_to_join_war = yes
+	
+	attacker_rel_head_is_ally = yes # The attacker can call his (main) Pope into the war
+	
+	can_use = {
+		ROOT = {
+			religion = FROM
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+			rightful_religious_head_scope = {
+				NOT = { has_claim = k_papal_state }
+				NOT = { has_claim = d_fraticelli }
+			}
+		}
+		FROM = {
+			rightful_religious_head_scope = {
+				is_liege_or_above = PREV
+				OR = {
+					has_claim = k_papal_state
+					has_claim = d_fraticelli
+				}
+			}
+		}
+	}
+	
+	is_valid = {
+		ROOT = {
+			religion = FROM
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+			rightful_religious_head_scope = {
+				NOT = { has_claim = k_papal_state }
+				NOT = { has_claim = d_fraticelli }
+			}
+		}
+		FROM = {
+			rightful_religious_head_scope = {
+				is_liege_or_above = PREV
+				OR = {
+					has_claim = k_papal_state
+					has_claim = d_fraticelli
+				}
+			}
+		}
+	}
+	
+	on_success = {
+		any_attacker = {
+			limit = { character = ROOT }
+			participation_scaled_piety = 500
+			participation_scaled_prestige = 250
+		}
+		any_attacker = {
+			limit = { NOT = { character = ROOT } }
+			hidden_tooltip = { 
+				participation_scaled_piety = 500
+				participation_scaled_prestige = 250
+			}
+		}
+		
+		ROOT = {
+			religion_authority = {
+				modifier = deposed_antipope
+				years = 50
+			}
+			
+			if = {
+				limit = {
+					rightful_religious_head_scope = {
+						ROOT = {
+							excommunicated_for = PREV
+						}
+					}
+				}
+				excommunicate = no
+			}
+			
+			rightful_religious_head_scope = {
+				opinion = {
+					who = ROOT
+					modifier = opinion_deposed_antipope
+				}
+			}
+		}
+		
+		FROM = { 
+			piety = -500
+			prestige = -250
+			
+			rightful_religious_head_scope = {
+				remove_claim = k_papal_state
+				remove_claim = d_fraticelli
+			}
+		}
+	}
+
+	on_fail = {
+		ROOT = { 
+			piety = -250
+			prestige = -125
+		}
+		FROM = { 
+			piety = 100
+			prestige = 50
+		}
+	}
+
+	on_reverse_demand = {
+		ROOT = {
+			transfer_scaled_wealth = {
+				to = FROM
+				value = 4.0
+			}
+			piety = -500
+			prestige = -250
+		}
+		
+		FROM = { 
+			piety = 500
+			prestige = 250
+		}
+	}
+
+	attacker_ai_victory_worth = {
+		factor = -1 # always accept
+	}
+	
+	attacker_ai_defeat_worth = {
+		factor = 100
+	}
+
+	defender_ai_victory_worth = {
+		factor = -1 # always accept
+	}
+	
+	defender_ai_defeat_worth = {
+		factor = 100
+	}
+}
+
+# Faction cb to install antiking
+cb_install_antiking = {
+	name = CB_NAME_INSTALL_ANTIKING
+	war_name = WAR_NAME_INSTALL_ANTIKING
+	sprite = 11
+	truce_days = 3650
+	major_revolt = yes
+	
+	attacker_rel_head_is_ally = yes # The attacker can call his (main) Pope into the war
+	
+	can_use = {
+		ROOT = {
+			vassal_of = FROM
+			religion = FROM
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+		}
+	}
+	
+	is_valid = {
+		ROOT = {
+			religion = FROM
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+		}
+	}
+	
+	on_success = {
+		any_attacker = {
+			limit = { character = ROOT }
+			participation_scaled_piety = 500
+			participation_scaled_prestige = 250
+		}
+		any_attacker = {
+			limit = { NOT = { character = ROOT } }
+			hidden_tooltip = { 
+				participation_scaled_piety = 500
+				participation_scaled_prestige = 250
+			}
+		}
+		
+		ROOT = {
+			religion_authority = {
+				modifier = deposed_antipope
+				years = 50
+			}
+			
+			if = {
+				limit = {
+					religion = catholic
+				}
+				k_papal_state = {
+					holder_scope = {
+						opinion = {
+							who = ROOT
+							modifier = opinion_deposed_antipope
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					religion = fraticelli
+				}
+				d_fraticelli = {
+					holder_scope = {
+						opinion = {
+							who = ROOT
+							modifier = opinion_deposed_antipope
+						}
+					}
+				}
+			}
+		}
+		
+		FROM = { 
+			piety = -500
+			prestige = -250
+			
+			hidden_tooltip = {
+				rightful_religious_head_scope = {
+					remove_claim = k_papal_state
+					remove_claim = d_fraticelli
+				}
+			}
+			
+			primary_title = {
+				usurp_title = ROOT
+			}
+		}
+		if = {
+			limit = { primary_title = { has_law = investiture_law_1 } }
+			primary_title = { add_law_w_cooldown = investiture_law_0 }
+		}
+	}
+
+	on_fail = {
+		ROOT = { 
+			piety = -250
+			prestige = -125
+		}
+		FROM = { 
+			piety = 100
+			prestige = 50
+		}
+	}
+
+	on_reverse_demand = {
+		ROOT = {
+			transfer_scaled_wealth = {
+				to = FROM
+				value = 4.0
+			}
+			piety = -500
+			prestige = -250
+			prisoner = FROM
+		}
+		
+		FROM = { 
+			piety = 500
+			prestige = 250
+		}
+	}
+
+	attacker_ai_victory_worth = {
+		factor = -1 # always accept
+	}
+	
+	attacker_ai_defeat_worth = {
+		factor = 100
+	}
+
+	defender_ai_victory_worth = {
+		factor = -1 # always accept
+	}
+	
+	defender_ai_defeat_worth = {
+		factor = 100
+	}
+}

--- a/ProjectBalance/common/objectives/00_factions.txt
+++ b/ProjectBalance/common/objectives/00_factions.txt
@@ -4392,3 +4392,394 @@ faction_claimant = {
 	effect = {
 	}
 }
+
+# Antiking Faction
+faction_antiking = {
+	type = liege_titles
+	
+	rel_head_loyalist = yes # Members consider the "real" pope to be the rightful religious head
+	cancel_on_leader_death = yes # The faction will not automatically continue under a new leader
+	
+	# Plotter scope
+	potential = {
+		is_ruler = yes
+		independent = no
+		is_landed = yes
+		is_adult = yes
+		OR = {
+			religion = catholic
+			religion = fraticelli
+		}
+		NOT = { trait = incapable }
+		primary_title = { higher_tier_than = COUNT }
+		liege = {
+			religion = ROOT
+			rightful_religious_head_scope = {
+				OR = {
+					has_claim = k_papal_state
+					has_claim = d_fraticelli
+				}
+			}
+		}
+		
+		NOT = { has_character_modifier = faction_antiking_ultimatum_timer }
+	}
+	
+	# Target scope
+	allow = {
+		higher_tier_than = DUKE
+		is_primary_holder_title = yes
+
+		holder_scope = {
+			independent = yes
+			NOT = {
+				any_war = {
+					war_title = ROOT
+					using_cb = cb_install_antiking
+				}
+			}
+			
+			NOT = {
+				reverse_has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_leaving_faction
+				}
+			}
+		}
+		
+		OR = {
+			culture = FROM
+			holder_scope = {
+				culture = FROM
+			}
+		}
+	}
+	
+	# If false, shows the faction entry for players, but disabled
+	player_allow = {
+		FROM = {
+			piety = 500
+		}
+	}
+	
+	# AI creation weight
+	chance = {
+		factor = 1
+		
+		modifier = {
+			factor = 0
+			FROM = { prisoner = yes }
+		}
+		
+		modifier = {
+			factor = 0
+			holder_scope = {
+				any_spouse = { character = FROM }
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			current_heir = {
+				character = FROM
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			FROM = {
+				OR = {
+					AND = {
+						NOT = { leads_faction = faction_antiking }
+						opinion = { who = LIEGE value = 25 } 
+					}
+					AND = {
+						leads_faction = faction_antiking
+						opinion = { who = LIEGE value = 50 } 
+					}
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0.2
+			FROM = { opinion = { who = LIEGE value = 5 } }
+		}
+		
+		modifier = {
+			factor = 1.5
+			NOT = { FROM = { opinion = { who = LIEGE value = -10 } } }
+		}
+		modifier = {
+			factor = 2.0
+			NOT = { FROM = { opinion = { who = LIEGE value = -50 } } }
+		}
+		modifier = {
+			factor = 4.0
+			NOT = { FROM = { opinion = { who = LIEGE value = -75 } } }
+		}
+		
+		modifier = {
+			factor = 0.25
+			NOT = { claimed_by = FROM }
+		}
+		
+		modifier = {
+			factor = 0.01
+			FROM = { trait = content }
+		}
+		modifier = {
+			factor = 0.01
+			FROM = { trait = imbecile }
+		}
+		modifier = {
+			factor = 0.1
+			FROM = { trait = inbred }
+		}
+		modifier = {
+			factor = 0.1
+			FROM = { trait = craven }
+		}
+		modifier = {
+			factor = 0.2
+			FROM = { trait = slow }
+		}
+		modifier = {
+			factor = 0.5
+			FROM = { trait = kind }
+		}
+		modifier = {
+			factor = 0.5
+			FROM = { trait = charitable }
+		}
+		modifier = {
+			factor = 0.5
+			FROM = { trait = honest }
+		}
+		modifier = {
+			factor = 0.75
+			FROM = { trait = humble }
+		}
+		modifier = {
+			factor = 0.75
+			FROM = { trait = just }
+		}
+		modifier = {
+			factor = 1.5
+			FROM = { trait = proud }
+		}
+		modifier = {
+			factor = 1.5
+			FROM = { trait = brave }
+		}
+		modifier = {
+			factor = 1.5
+			FROM = { trait = arbitrary }
+		}
+		modifier = {
+			factor = 2.0
+			FROM = { trait = envious }
+		}
+		modifier = {
+			factor = 2.0
+			FROM = { trait = greedy }
+		}
+		modifier = {
+			factor = 2.0
+			FROM = { trait = impaler }
+		}
+		modifier = {
+			factor = 2.0
+			FROM = { trait = deceitful }
+		}
+		modifier = {
+			factor = 4.0
+			FROM = { trait = ambitious }
+		}
+	}
+	
+	# AI membership weight: ROOT is the prospective member. FROM is the faction leader. FROMFROM is the target title or character.
+	membership = {
+		factor = 1
+		
+		modifier = {
+			factor = 0
+			OR = {
+				prisoner = yes
+				trait = incapable
+				is_adult = no
+				is_landed = no
+				preparing_invasion = yes
+				NOT = { religion = FROM }
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			FROMFROM = {
+				current_heir = {
+					character = ROOT
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			has_character_modifier = faction_antiking_ultimatum_timer
+		}
+		
+		modifier = {
+			factor = 0
+			
+			OR = {
+				AND = {
+					NOT = { in_faction = faction_antiking }
+					opinion = { who = LIEGE value = 25 } 
+				}
+				AND = {
+					in_faction = faction_antiking
+					opinion = { who = LIEGE value = 50 } 
+				}
+			}
+			
+			NOT = {	
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			NOT = { opinion = { who = FROM value = -40 } }
+			NOT = {	
+				has_opinion_modifier = {
+					who = FROM
+					modifier = opinion_coerced_into_joining_faction
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			has_opinion_modifier = {
+				who = LIEGE
+				modifier = opinion_coerced_into_leaving_faction
+			}
+		}
+		
+		modifier = {
+			factor = 0.2
+			opinion = { who = LIEGE value = 5 }
+		}
+		
+		modifier = {
+			factor = 10000
+			has_opinion_modifier = {
+				who = FROM
+				modifier = opinion_coerced_into_joining_faction
+			}
+		}
+		
+		modifier = {
+			factor = 1.5
+			NOT = { opinion = { who = LIEGE value = -10 } }
+		}
+		modifier = {
+			factor = 2.0
+			NOT = { opinion = { who = LIEGE value = -50 } }
+		}
+		modifier = {
+			factor = 4.0
+			NOT = { opinion = { who = LIEGE value = -75 } }
+		}
+		
+		modifier = {
+			factor = 0.01
+			trait = content
+		}
+		modifier = {
+			factor = 0.01
+			trait = imbecile
+		}
+		modifier = {
+			factor = 0.1
+			trait = inbred
+		}
+		modifier = {
+			factor = 0.1
+			trait = craven
+		}
+		modifier = {
+			factor = 0.2
+			trait = slow
+		}
+		modifier = {
+			factor = 0.5
+			trait = kind
+		}
+		modifier = {
+			factor = 0.5
+			trait = charitable
+		}
+		modifier = {
+			factor = 0.5
+			trait = honest
+		}
+		modifier = {
+			factor = 0.75
+			trait = humble
+		}
+		modifier = {
+			factor = 0.75
+			trait = just
+		}
+		modifier = {
+			factor = 1.5
+			trait = proud
+		}
+		modifier = {
+			factor = 1.5
+			trait = brave
+		}
+		modifier = {
+			factor = 1.5
+			trait = arbitrary
+		}
+		modifier = {
+			factor = 2.0
+			trait = envious
+		}
+		modifier = {
+			factor = 2.0
+			trait = greedy
+		}
+		modifier = {
+			factor = 2.0
+			trait = impaler
+		}
+		modifier = {
+			factor = 2.0
+			trait = deceitful
+		}
+		modifier = {
+			factor = 4.0
+			trait = ambitious
+		}
+	}
+	
+	success = {
+		always = no
+	}
+	
+	abort = {
+		always = no
+	}
+	
+	abort_effect = {
+	}
+	
+	effect = {
+	}
+}


### PR DESCRIPTION
Should put a check in place against anti-popes, as it has with vanilla.  All the code checks-out, no worthwhile modifications from vanilla.
