### PR TITLE
Ongoing crusade fixes

### DIFF
--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -3317,7 +3317,7 @@ crusade = {
 						}
 					}
 				}
-				PREV = {
+				kingdom = {
 					holder_scope = {
 						usurp_title = PREVPREV
 					}
@@ -3354,7 +3354,7 @@ crusade = {
 								}
 							}
 						}
-						PREV = {
+						kingdom = {
 							holder_scope = {
 								usurp_title = PREVPREVPREV
 							}

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -3342,25 +3342,6 @@ crusade = {
 					title = PREV
 					enemy = FROM
 				}
-				PREV = {
-					any_de_jure_vassal_title = {
-						limit = {
-							holder_scope = { #Handle revolters
-								top_liege = { #Should work at any level of revolt
-									in_revolt = yes
-									liege_before_war = {
-										character = FROM
-									}
-								}
-							}
-						}
-						kingdom = {
-							holder_scope = {
-								usurp_title = PREVPREVPREV
-							}
-						}
-					}
-				}
 				if  = {
 					limit = {
 						#primary_title = { is_primary_type_title = no } # Mercs, the Pope, Holy Orders, etc
@@ -3374,6 +3355,26 @@ crusade = {
 						}
 					}
 					usurp_title = PREV
+					
+					PREV = {
+						any_de_jure_vassal_title = {
+							limit = {
+								holder_scope = { #Handle revolters
+									top_liege = { #Should work at any level of revolt
+										in_revolt = yes
+										liege_before_war = {
+											character = FROM
+										}
+									}
+								}
+							}
+							kingdom = {
+								holder_scope = {
+									usurp_title = PREVPREV
+								}
+							}
+						}
+					}
 					
 					if = {
 						limit = {


### PR DESCRIPTION
Not much to show for a lot of effort, but I'm aware of numerous other uncovered cases and unintentional side-effects of the current crusade CB now (and the events) and poised to fix those in the future.  Nothing is game-breaking or requiring critical attention.  Also, I've now confirmed at least one flaw in vanilla's CB too, FWIW.

BTW, though I did confirm that you can easily move CB support code out of the critical path in the CB and into events while retaining all necessary information (FROM => FROMFROM & ROOT => FROM, as logical), the final fix for the nested-PREVs issue was to simply not nest them and rely on the fact that the CB is **check_de_jure_tier = KING**, simply using _kingdom_ in place of _PREV_.

/slap

I did confirm that the old code, in either case, was not working at all due to scope problems-- even when the holder was already in the right hands and under simplified conditions for the _any_de_jure_vassal_title_ limit (the new, fancy _liege_before_war_ condition remains untested-- replaced with a dummy to focus on the scope problems).

This is not a conclusion: crusades are a few fixes away from done.  Even the final bugfix is flawed (but at least does something correct most of the time, unlike before).  I ran out of time.

As for my quest to discover the hidden magic of how nested PREV scoping works in CKII, the gist of **that** conclusion: there is no hidden magic.  Apparently, CKII doesn't even have the EU4 behavior to which I alluded.  It always just breaks and does almost never what you want it to do.  When it does, it's a coincidence.  Never nest PREV, unless you truly want to pop multiple levels of the stack at once (and never be able to reference where you were within the new scope).
