### PR TITLE
Tribal Invasion CB Fix

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -18,6 +18,7 @@
 	The CB other_succession_on_liege (third-party pushing a succession claim against his liege) now properly converts the claimant to feudal type (vs. clergy, e.g.), whenever appropriate (reporting credit goes to AnaxXiphos)
 	Fixed an issue with the CB description localisation/text for Muslim County Conquest (reporting credit goes to AnaxXiphos)
 	Very slightly buffed new crusader state formation; added consistency, flavor, and fixes
+	Fixed tribal invasion cb not allowing Mongols to invade non-Mongols
 
 3.4.2
 	Shattered Balance, No Ahistorical Empires, and Gender Equality can now be enabled in-game before first unpausing the game

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -2855,8 +2855,10 @@ tribal_invasion = {
 		}
 		OR = {
 			NOT = {
+				AND = {
 				FROM = { culture = mongol }
 				ROOT = { culture = mongol }
+				}
 			}
 			year = 1350
 		}


### PR DESCRIPTION
I've tested this in-game with Ilkhanate pre-1350 to use tribal invasion cb on non-Mongols whereas before this was not possible. I was also correctly unable to invade Golden Horde with over 150 prestige as it shouldn't be possible pre-1350.
