### PR TITLE
More event picture tweaks

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,7 +1,7 @@
 3.4.4
 	(PB+VIET) Fixed some trait icons being missing when VIET Immersion is active
 	Fixed an issue with pushing the claims of vassals/courtiers
-	Updated employment decision icons [AnaxXiphos]
+	Updated employment decision icons, changed more event pictures [AnaxXiphos]
 	(PB+SWMH) Fixed an issue with the Imperial Reconquest CB
 
 3.4.3

--- a/ProjectBalance/events/PB_culture.txt
+++ b/ProjectBalance/events/PB_culture.txt
@@ -1038,7 +1038,7 @@ character_event = {
 province_event = {
 	id = meneth.4
 	desc = "EVTDESC55000"
-	picture = GFX_evt_throne_room
+	picture = GFX_evt_carriage
 	
 	trigger = {
 		culture_group = celtic
@@ -1149,7 +1149,7 @@ province_event = {
 province_event = {
 	id = meneth.5
 	desc = "EVTDESC55001"
-	picture = GFX_evt_carriage
+	picture = GFX_evt_busy_trading_dock_republic
 	
 	trigger = {
 		culture_group = celtic
@@ -1222,7 +1222,7 @@ province_event = {
 province_event = {
 	id = meneth.6
 	desc = "EVTDESC55000"
-	picture = GFX_evt_throne_room
+	picture = GFX_evt_carriage
 	
 	trigger = {
 		OR = {
@@ -1351,7 +1351,7 @@ province_event = {
 province_event = {
 	id = meneth.7
 	desc = "EVTDESC55001"
-	picture = GFX_evt_carriage
+	picture = GFX_evt_busy_trading_dock_republic
 	
 	trigger = {
 		OR = {

--- a/ProjectBalance/events/PB_historical.txt
+++ b/ProjectBalance/events/PB_historical.txt
@@ -124,8 +124,8 @@ character_event = {
 character_event = {
 	id = meneth.401
 	desc = meneth.401.desc
-	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_war
+	picture = GFX_evt_council_muslim
+	border = GFX_event_normal_frame_diplomacy
 	
 	is_triggered_only = yes
 	
@@ -2020,7 +2020,7 @@ character_event = {
 	id = meneth.422
 	desc = meneth.422.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2056,7 +2056,7 @@ character_event = {
 	id = meneth.429
 	desc = meneth.429.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2089,7 +2089,7 @@ character_event = {
 	id = meneth.430
 	desc = meneth.430.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2119,7 +2119,7 @@ character_event = {
 	id = meneth.431
 	desc = meneth.431.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2149,7 +2149,7 @@ character_event = {
 	id = meneth.432
 	desc = meneth.432.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2193,7 +2193,7 @@ character_event = {
 	id = meneth.433
 	desc = meneth.433.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2229,7 +2229,7 @@ character_event = {
 	id = meneth.434
 	desc = meneth.432.desc
 	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_religion
+	border = GFX_event_normal_frame_war
 	
 	only_rulers = yes
 	
@@ -2331,8 +2331,8 @@ character_event = {
 character_event = {
 	id = meneth.426
 	desc = meneth.426.desc
-	picture = GFX_evt_battle
-	border = GFX_event_normal_frame_war
+	picture = GFX_evt_carriage
+	border = GFX_event_normal_frame_diplomacy
 	
 	is_triggered_only = yes
 	

--- a/ProjectBalance/events/PB_startup_2.txt
+++ b/ProjectBalance/events/PB_startup_2.txt
@@ -541,7 +541,7 @@ narrative_event = {
 	
 	is_triggered_only = yes
 	
-	picture = "GFX_evt_battle"
+	picture = GFX_evt_monk_muslim
 	
 	trigger = {
 		NOT = { has_global_flag = shattered_balance }
@@ -570,7 +570,7 @@ narrative_event = {
 	is_triggered_only = yes
 	hide_from = yes
 	
-	picture = "GFX_evt_battle"
+	picture = GFX_evt_monk_muslim
 	
 	trigger = {
 		NOT = { has_global_flag = shattered_balance }


### PR DESCRIPTION
For culture events, port spread events get port picture, neighboring province spread events get carriage picture, ruler spread events stay with throne room picture; Baqt change is better than battle, I think, but hopefully we'll get a proper trade caravan picture with RoI
