### PR TITLE
Fixes for Muslim Invasion CB

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -4,6 +4,7 @@
 	Updated employment decision icons, changed more event pictures [AnaxXiphos]
 	(PB+SWMH) Fixed an issue with the Imperial Reconquest CB
 	Bugfix for immediately-invalidated Muslim Invasion CB; muslim-vs.-muslim invasion (due to hostile denomination) is now 60% more expensive than vanilla to wage and more difficult to qualify, but all other cases mirror vanilla
+	The Yazidi Caliphate, if it comes into existence, may now also use the Caliphal Subjugation CB
 
 3.4.3
 	Bugfix for Jewish players not being able to take loans via the decisions menu. AI Jews could still take loans

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -3,6 +3,7 @@
 	Fixed an issue with pushing the claims of vassals/courtiers
 	Updated employment decision icons, changed more event pictures [AnaxXiphos]
 	(PB+SWMH) Fixed an issue with the Imperial Reconquest CB
+	Bugfix for immediately-invalidated Muslim Invasion CB; muslim-vs.-muslim invasion (due to hostile denomination) is now 60% more expensive than vanilla to wage and more difficult to qualify, but all other cases mirror vanilla
 
 3.4.3
 	Bugfix for Jewish players not being able to take loans via the decisions menu. AI Jews could still take loans

--- a/ProjectBalance/common/cb_types/Old Gods.txt
+++ b/ProjectBalance/common/cb_types/Old Gods.txt
@@ -1086,6 +1086,7 @@ caliphal_subjugation = {
 			OR = {
 				has_landed_title = d_sunni
 				has_landed_title = k_shiite
+				has_landed_title = d_yazidi #Also has a qualifying head of religion
 			}
 			has_horde_culture = no # Should use tribal invasion instead
 			NOT = { has_character_modifier = launched_subjugation }

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -8210,25 +8210,49 @@ muslim_invasion = {
 	can_use_gui = {
 		ROOT = {
 			NOT = { has_character_modifier = holy_war_cooldown }
-			piety = 500
+			NOT = { decadence = 50 } # Helps curb decadence growth anyway: no titles in this CB are usurped
+			
 			NOT = { trait = content }
 			NOT = { trait = slothful }
 			NOT = { trait = imbecile }
 			NOT = { trait = craven }
-			NOT = { decadence = 50 }
+			
 			is_republic = no
 			is_patrician = no
+			
+			# ROOT is a muslim, but FROM is not the same religion (due to can_use)...
+			
 			OR = {
-				FROM = { religion_group = ROOT }
-				trait = brave
-				trait = wroth
-				trait = zealous
-				trait = lunatic
-				trait = possessed
+				AND = { # Standard vanilla case, but we only use their requirements outside the muslim group
+					FROM = { NOT = { religion_group = ROOT } } }
+					piety = 500 # Costs piety (in addition to DoW initial cost)
+				}
+				AND = {	# If FROM _is also_ a Muslim (of a hostile denomination), ROOT meets more strict requirements
+					FROM = { religion_group = ROOT }
+					piety = 800 # Costs 60% more piety; no piety cycle in this CB (also DoW cost and monthly cost)
+					prestige = 800 # Not a cost, but prestige must be built before MvM invasion is enabled
+					
+					OR = { # More serious trait requirements than usual (possibly too strict)
+						AND = {
+							trait = zealous # Deal-breaker
+							OR = {
+								FROM = { trait = zealous } # Zeal v. zeal crime (hostile Muslims)
+								trait = brave
+								trait = wroth
+								trait = ambitious
+							}
+						}
+						trait = lunatic
+						trait = possessed
+					}
+				}
 			}
 		}
+		
+		#Muslims cannot invade pagans with this CB; zoroastrians and jews (and hindus) are fine
 		FROM = { NOT = { religion_group = pagan_group } }
-		OR = {
+		
+		OR = { #Enforce the Baqt
 			NOT = {
 				FROM = {
 					OR = {
@@ -8240,7 +8264,7 @@ muslim_invasion = {
 			}
 			has_global_flag = violated_baqt
 		}
-		OR = {
+		OR = { #Avoid mongol-on-mongol crime before 1350
 			NOT = {
 				FROM = { culture = mongol }
 				ROOT = { culture = mongol }
@@ -8251,18 +8275,22 @@ muslim_invasion = {
 	
 	on_add = {
 		ROOT = {
-			piety = -500
+			if = { limit = { religion_group = FROM }
+				piety = -800 #MvM invasion costs more (avoid piety cycle, note on_success does as well with decadence)
+			}
+			if = { limit = { NOT = { religion_group = FROM } }
+				piety = -500 #Vanilla (always)
+			}
 			add_character_modifier = {
 				name = holy_war_cooldown
 				duration = 1825
 			}
 		}
 	}
-	
+
 	can_use = {
 		ROOT = {
 			religion_group = muslim
-			NOT = { is_liege_or_above = FROM }
 		}
 		
 		NOT = {
@@ -8284,6 +8312,10 @@ muslim_invasion = {
 		}
 		
 		FROM = { NOT = { religion = ROOT } }
+		
+		ROOT = {
+			NOT = { is_liege_or_above = FROM }
+		}
 	}
 	
 	can_use_title = {
@@ -8294,6 +8326,14 @@ muslim_invasion = {
 				title = PREV
 			}
 		}
+
+		# Z: The bordering case in vanilla is "broken" (only requires bordering _any_
+		#    province in the target kingdom if no provinces of own within kingdom--
+		#    that province does not need to be one over which FROM is overlord, and
+		#    that is a recipe for Blobs Without Borders (or, Holey Blobs, if you must).
+		#
+		#    TODO: Fix should probably be applied, elsewhere as well. Held for now.
+
 		# The attacker needs at least one county in the target kingdom, or a border
 		any_direct_de_jure_vassal_title = {
 			any_direct_de_jure_vassal_title = {
@@ -8305,6 +8345,13 @@ muslim_invasion = {
 						}
 					}
 					location = {
+						# Pre-staged "fix" for Blobs w/ Holes
+#						owner = {
+#							OR = {
+#								character = FROM
+#								is_liege_or_above = FROM
+#							}
+#						}
 						any_neighbor_province = {
 							owner = {
 								OR = {
@@ -8317,7 +8364,7 @@ muslim_invasion = {
 				}
 			}
 		}
-		OR = {
+		OR = { #No targets covering Saharan provinces
 			has_global_flag = rapid_conquest
 			NOT = {
 				any_direct_de_jure_vassal_title = {
@@ -8330,9 +8377,10 @@ muslim_invasion = {
 	}
 	
 	is_valid = {
-		FROM = {
-			NOT = { religion_group = muslim }
+		ROOT = {
+			religion_group = muslim
 		}
+		FROM = { NOT = { religion = ROOT } }
 	}
 	
 	is_valid_title = {
@@ -8353,23 +8401,40 @@ muslim_invasion = {
 			participation_scaled_prestige = 200
 			
 			if = {
-				limit = {
-					religion_group = muslim
-					FROM = { NOT = { religion_group = muslim } }
+				limit = { religion_group = muslim }
+				if = {
+					limit = {
+						FROM = { NOT = { religion_group = muslim } }
+					}
+					participation_scaled_decadence = -20
 				}
-				participation_scaled_decadence = -20
+				if = {
+					limit = {
+						FROM = { religion_group = muslim }
+					}
+					participation_scaled_decadence = -10 #Less decadence loss for [hostile] MvM war
+				}
 			}
 		}
 		any_attacker = {
 			limit = { NOT = { character = ROOT } }
 			hidden_tooltip = { 
-				participation_scaled_prestige = 200 
+				participation_scaled_prestige = 200
+				
 				if = {
-					limit = {
-						religion_group = muslim
-						FROM = { NOT = { religion_group = muslim } }
+					limit = { religion_group = muslim }
+					if = {
+						limit = {
+							FROM = { NOT = { religion_group = muslim } }
+						}
+						participation_scaled_decadence = -20
 					}
-					participation_scaled_decadence = -20
+					if = {
+						limit = {
+							religion_group = FROM
+						}
+						participation_scaled_decadence = -10 #Less decadence loss for [hostile] MvM war, allied
+					}
 				}
 			}
 		}
@@ -8379,32 +8444,14 @@ muslim_invasion = {
 	}
 	
 	on_success_title = {
-		custom_tooltip = {
-			text = invasion_succ_tip
+		custom_tooltip = { 
+			text = tribal_invasion_succ_tip
 			hidden_tooltip = {
 				ROOT = {
-					vassalize_or_take_under_title = {
+					vassalize_or_take_under_title_destroy_duchies = {
 						title = PREV
 						enemy = FROM
 						is_crusade = yes # Even if the title holder is not participating in the war, gain holdings occupied by all Crusade participants
-					}
-				}
-				any_de_jure_vassal_title = {
-					limit = {
-						holder_scope = {
-							independent = no
-							liege = {
-								character = PREV
-							}
-							any_war = {
-								defender = {
-									character = FROM
-								}
-							}
-						}
-					}
-					holder_scope = {
-						set_defacto_liege = ROOT
 					}
 				}
 			}


### PR DESCRIPTION
### muslim_invasion CB

A few fixes. It also conforms with the vanilla diff wherever possible now.  Muslim vs. muslim invasion is enabled (of hostile denominations only) as it technically was already, but in such a case, it costs 60% more piety on_add than vanilla (800), cancels less decadence, and has very strict requirements upon usage.  Muslim vs. other religious group (aside from pagan) invasions operate exactly as per vanilla with the usual PB restrictions.
