### PR TITLE
Some religious fixes

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -3,6 +3,7 @@
 	Properly localised Novgorod events and made some other localisation flavor adjustments
 	Holy war no longer vassalizes anyone not of your religion; they're once more conquered outright. Note that Pagans have a decision from vanilla that makes them convert and invalidates holy war
 	Removed some coats of arms that already exist in vanilla
+	Free any vassalized landless holy order titles of wrong religion upon success of a crusade/jihad/GHW. Previously, they'd be stuck (unable to be hired nor interact with their own religion normally anymore) essentially forever under, e.g., the winning Caliph of a Jihad if they were vassals to Jerusalem beforehand.
 
 3.5.4
 	Fixed a few kingdoms incorrectly remaining parts of dejure empires when No Ahistorical Empires is enabled

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,6 +1,7 @@
 3.5.5 [BETA]
 	Mending the schism as a catholic now always requires a catholic to hold the Hagia Sophia, even if there's no Orthodox empire in existence. This should make mending the schism considerably rarer
 	Properly localised Novgorod events and made some other localisation flavor adjustments
+	Free any vassalized landless holy order titles of wrong religion upon success of a crusade/jihad/GHW. Previously, they'd be stuck (unable to be hired nor interact with their own religion normally anymore) essentially forever under, e.g., the winning Caliph of a Jihad if they were vassals to Jerusalem beforehand.
 
 3.5.4
 	Fixed a few kingdoms incorrectly remaining parts of dejure empires when No Ahistorical Empires is enabled

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -3,7 +3,7 @@
 	Properly localised Novgorod events and made some other localisation flavor adjustments
 	Holy war no longer vassalizes anyone not of your religion; they're once more conquered outright. Note that Pagans have a decision from vanilla that makes them convert and invalidates holy war
 	Removed some coats of arms that already exist in vanilla
-	Free any vassalized landless holy order titles of wrong religion upon success of a crusade/jihad/GHW. Previously, they'd be stuck (unable to be hired nor interact with their own religion normally anymore) essentially forever under, e.g., the winning Caliph of a Jihad if they were vassals to Jerusalem beforehand.
+	Upon crusade/jihad/GHW success, free any vassalized holy orders which do not match the winner's religion. Previously, they'd essentially become stuck forever under, e.g., the winner of a Jihad, if they were vassals of Jerusalem beforehand (unable to be hired by any religion and possibly giving a Caliphate vassal baronies randomly located throughout Catholic Europe)
 
 3.5.4
 	Fixed a few kingdoms incorrectly remaining parts of dejure empires when No Ahistorical Empires is enabled

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -3340,7 +3340,7 @@ crusade = {
 		hidden_tooltip = {
 			add_law = the_crusade_target #Flag the title (terrible hack-- thanks, Paradox!)
 		}
-		
+
 		# Already-held by same-religion holder case (give land to them)
 		if = {
 			limit = {
@@ -3358,9 +3358,12 @@ crusade = {
 			}
 			hidden_tooltip = {
 				holder_scope = { character_event = { id = pb_crusades.0 } } #Handle revolters [immediately]
+				
+				# Refill all the levies, remove the conquest modifiers, and revoke the target law in 1 day
+				character_event = { id = pb_crusades.11 days = 1 }
 			}
 		}
-		
+
 		# Not-held or different-religion holder case (give land to... someone)
 		if = {
 			limit = {
@@ -3373,27 +3376,17 @@ crusade = {
 					}
 				}
 			}
-			
+
 			most_participating_attacker = {
 				gain_settlements_under_title = {
 					title = PREV
 					enemy = FROM
 				}
-				
+
 				usurp_title = PREV # Usurp or create, whichever.
-								
+
 				hidden_tooltip = {
 					character_event = { id = pb_crusades.0 } #Handle revolters [immediately]
-
-					any_demesne_title = {
-						limit = {
-							de_jure_liege_or_above = PREVPREV
-							tier = baron
-						}
-						remove_holding_modifier = recently_conquered
-						remove_holding_modifier = new_administration
-						refill_holding_levy = yes
-					}
 					
 					if = {
 						limit = {
@@ -3407,10 +3400,6 @@ crusade = {
 					}
 				}
 			}
-		}
-		
-		hidden_tooltip = {
-			revoke_law = the_crusade_target # Remove our title "flag"
 		}
 		
 		any_attacker = {

--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -3384,8 +3384,9 @@ crusade = {
 				}
 
 				usurp_title = PREV # Usurp or create, whichever.
-
+				
 				hidden_tooltip = {
+					character_event = { id = pb_crusades.12 } #Free holy orders from vassalage
 					character_event = { id = pb_crusades.0 } #Handle revolters [immediately]
 					
 					if = {

--- a/ProjectBalance/events/PB_crusades.txt
+++ b/ProjectBalance/events/PB_crusades.txt
@@ -948,3 +948,29 @@ character_event = {
 		name = OK
 	}
 }
+
+# pb_crusades.12
+# Free holy orders of wrong religion from target kingdom title vassalage (CB supplement)
+#
+# FROMFROM is CB giver (loser in this case), ROOT is the winner, and
+# FROM is the Pope (or Caliph or whoever was the primary attacker).
+character_event = {
+	id = pb_crusades.12
+	desc = OK
+	hide_window = yes
+	is_triggered_only = yes
+	
+	immediate = {
+		any_realm_lord = {
+			limit = {
+				NOT = { religion = ROOT }
+				primary_title = { holy_order = yes }
+			}
+			set_defacto_liege = THIS
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}

--- a/ProjectBalance/events/PB_crusades.txt
+++ b/ProjectBalance/events/PB_crusades.txt
@@ -93,7 +93,8 @@ character_event = {
 			ai = no
 		}
 		hidden_tooltip = {
-			revoke_law = the_crusade_target
+			# Refill all the levies, remove the conquest modifiers, and revoke the target law in 1 day
+			character_event = { id = pb_crusades.11 days = 1 }
 		}
 		ai_chance = {
 			factor = 0
@@ -328,8 +329,6 @@ character_event = {
 # pb_crusades.2
 # Crusader State Granted to New Ruler [immediate]
 #
-# Moved from meneth.207 (out of PB_various.txt)
-#
 # ROOT = non-ruler (ergo, AI)
 # FROM = giver of crusade target kingdom
 # FROMFROM = initiator of crusade
@@ -370,7 +369,9 @@ character_event = {
 				}
 				
 				grant_title = ROOT
-				revoke_law = the_crusade_target # No need to track the crusade target any longer
+				
+				# Refill all the levies, remove the conquest modifiers, and revoke the target law in 1 day
+				character_event = { id = pb_crusades.11 days = 1 }
 			}
 		} # Title transfer complete
 		
@@ -906,5 +907,44 @@ character_event = {
 		wealth = 200
 		change_variable = { which = crusade_cash value = -1 }
 		character_event = { id = pb_crusades.10 }
+	}
+}
+
+
+# pb_crusades.11
+# Remove conquest modifiers and refill levies of holdings on_success (CB supplement)
+#
+# Also happens to be the last event to use the_crusage_target title law, so it must
+# take care of revoking it.
+#
+# FROMFROM is CB giver (loser in this case), ROOT is the winner, and
+# FROM is the Pope (or Caliph or whoever was the primary attacker).
+character_event = {
+	id = pb_crusades.11
+	desc = OK
+	hide_window = yes
+	is_triggered_only = yes
+	
+	immediate = {		
+		random_demesne_title = {
+			limit = {
+				has_law = the_crusade_target
+			}
+			
+			any_de_jure_vassal_title = {
+				limit = {
+					tier = baron
+				}
+				remove_holding_modifier = recently_conquered
+				remove_holding_modifier = new_administration
+				refill_holding_levy = yes
+			}
+			
+			revoke_law = the_crusade_target
+		}
+	}
+	
+	option = { 
+		name = OK
 	}
 }


### PR DESCRIPTION
More minor crusade stuff.  The holy order fix is essential for all games started after the historical 1st crusade, though.  Basically, you completely disabled holy orders in effect within a few years into the game without that commit.
