### PR TITLE
Create 00_special_troops.txt

### DIFF
--- a/ProjectBalance/special_troops/00_special_troops.txt
+++ b/ProjectBalance/special_troops/00_special_troops.txt
@@ -1,0 +1,35 @@
+horse_archers = {
+	morale = 5
+	maintenance = 3
+	phase_skirmish_attack = 4
+	phase_melee_attack = 3
+	phase_pursue_attack = 7
+	phase_skirmish_defense = 4
+	phase_melee_defense = 4
+	phase_pursue_defense = 7
+	base_type = light_cavalry
+}
+
+war_elephants = {
+	morale = 15
+	maintenance = 30
+	phase_skirmish_attack = 0.25
+	phase_melee_attack = 25
+	phase_pursue_attack = 3
+	phase_skirmish_defense = 12
+	phase_melee_defense = 20
+	phase_pursue_defense = 4
+	base_type = heavy_cavalry
+}
+
+camel_cavalry = {
+	morale = 5
+	maintenance = 3
+	phase_skirmish_attack = 3
+	phase_melee_attack = 6
+	phase_pursue_attack = 3
+	phase_skirmish_defense = 4
+	phase_melee_defense = 4
+	phase_pursue_defense = 3
+	base_type = light_cavalry
+}


### PR DESCRIPTION
There was no 00_special_troops.txt, so PB was just using the vanilla special unit definitions, and didn't have the increased maintenance for camel cavalry or horse archers. Problem solved!
