### PR TITLE
Hopefully fixed the other_claim_on_liege CB

### DIFF
--- a/ProjectBalance/common/cb_types/Vanilla CBs.txt
+++ b/ProjectBalance/common/cb_types/Vanilla CBs.txt
@@ -1714,15 +1714,13 @@ other_claim_on_liege = {
 	}
 	
 	is_valid = {
-		ROOT = {
-			OR = {
-				liege = {
-					character = PREV # either independent
-				}
-				liege = { 
-					FROM = { 
-						is_liege_or_above = PREV # or have shared liege
-					}
+		OR = {
+			liege = {
+				character = PREV # either independent
+			}
+			liege = { 
+				FROM = { 
+					is_liege_or_above = PREV # or have shared liege
 				}
 			}
 		}
@@ -8694,11 +8692,30 @@ cb_install_antiking = {
 	}
 	
 	is_valid = {
+		NOT = { 
+			holder_scope = { 
+				character = ROOT 
+			} 
+		}	
+	
 		ROOT = {
 			religion = FROM
 			OR = {
 				religion = catholic
 				religion = fraticelli
+			}
+		}
+		
+		ROOT = {
+			OR = {
+				liege = {
+					character = PREV # either independent
+				}
+				liege = { 
+					FROM = { 
+						is_liege_or_above = PREV # or have shared liege
+					}
+				}
 			}
 		}
 	}
@@ -8814,21 +8831,6 @@ cb_install_antiking = {
 	
 	defender_ai_defeat_worth = {
 		factor = 100
-	}
-	
-	is_valid = {
-		ROOT = {
-			OR = {
-				liege = {
-					character = PREV # either independent
-				}
-				liege = { 
-					FROM = { 
-						is_liege_or_above = PREV # or have shared liege
-					}
-				}
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
At any rate, this is the only difference between it and the vanilla version which doesn't seem intentional, so if it doesn't fix the issue then it's probably a vanilla problem. (I also brought the cb_install_antiking in line with the latest version. For some reason it had two is_valid blocks and was missing a holder_scope check.)
