### PR TITLE
Fix holy order decisions

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,5 @@
 ﻿3.5.12
+	Reformed Tengri can now donate to and expel their holy order (vanilla bug fix)
 	Tweaks to Religious Authority defines to better balance Sunnis, Shia, and prevent pathological Catholic downward spirals sparked by the inevitable antipope:
 		AUTHORITY_FROM_ANTIPOPE = -0.2 (from -0.3)
 		AUTHORITY_FROM_RELHEAD_HOLY_SITE = 0 (from 0.05)

--- a/ProjectBalance/decisions/holy_order_decisions.txt
+++ b/ProjectBalance/decisions/holy_order_decisions.txt
@@ -1858,7 +1858,7 @@ decisions = {
 	expel_sky_lords = {
 		potential = {
 			ai = no
-			religion = tengri_pagan #tengri_pagan_reformed
+			religion = tengri_pagan_reformed #tengri_pagan_reformed
 			higher_tier_than = DUKE
 			independent = yes
 			is_title_active = d_sky_lords
@@ -1919,7 +1919,7 @@ decisions = {
 	
 	donate_money_to_sky_lords = {
 		potential = {
-			religion = tengri_pagan #tengri_pagan_reformed
+			religion = tengri_pagan_reformed #tengri_pagan_reformed
 			
 			is_title_active = d_sky_lords
 			


### PR DESCRIPTION
Sky Lords only appear after reformation, but for some reason vanilla limits interaction to non-reformed Tengri; so this fixes that.
