### PR TITLE
Blocked Monks and Nuns from desiring landed titles

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,5 @@
 ﻿3.5.12
+	Monks and Nuns are now blocked from Wants Landed Title ambition
 	Plot events and faction decisions updated, should allow antiking faction to function properly
 	Reformed Tengri can now donate to and expel their holy order (vanilla bug fix)
 	Tweaks to Religious Authority defines to better balance Sunnis, Shia, and prevent pathological Catholic downward spirals sparked by the inevitable antipope:

--- a/ProjectBalance/common/objectives/00_ambitions.txt
+++ b/ProjectBalance/common/objectives/00_ambitions.txt
@@ -1006,6 +1006,9 @@ obj_wants_landed_title = {
 				}
 			}
 		}
+		# PB: Additional restrictions to block folks who have no business wanting titles
+		NOT = { trait = monk }
+		NOT = { trait = nun }
 	}
 	
 	chance = {


### PR DESCRIPTION
They aren't supposed to be able to inherit, and they certainly shouldn't be sending you demands to land them
