### PR TITLE
Fix for succession law glitch

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,6 @@
 ﻿3.5.12
+	Succession law opinions should now be properly applied to a ruler's family (this issue was also caused by a vanilla bug)
+	Gender Equality module now properly removes crippling negative opinions (this issue was caused by a vanilla bug)
 	Job ambitions now have the same restrictions as found in job_titles.txt
 	Monks, Nuns, and the Celibate are now blocked from Wants Landed Title ambition
 	Plot events and faction decisions updated, should allow antiking faction to function properly

--- a/ProjectBalance/decisions/succession_laws.txt
+++ b/ProjectBalance/decisions/succession_laws.txt
@@ -39,6 +39,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					holder_scope = {
@@ -129,6 +130,7 @@ succession_laws = {
 		
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {
@@ -227,6 +229,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {
@@ -321,6 +324,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					NOT = { has_law = revokation_2 }
@@ -400,6 +404,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					holder_scope = {
@@ -480,6 +485,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
+				is_ruler = no # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {


### PR DESCRIPTION
Just to clarify: It looks like adding `allow = {}` blocks to succession laws causes the game to only apply the succession related opinion modifiers to characters who meet the requirements inside that allow. And it looks like it also mixes up scopes when it does so, since adding `is_ruler = no` shouldn't work in what should be a title scope, but it clearly does. Note that I tested this fix fairly thoroughly, but it's possible it isn't going to cover every case; anyone playing should keep a weather eye out for those modifiers just in case.
