### PR TITLE
Hide the ugly succession workaround

### DIFF
--- a/ProjectBalance/decisions/succession_laws.txt
+++ b/ProjectBalance/decisions/succession_laws.txt
@@ -39,7 +39,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					holder_scope = {
@@ -130,7 +130,7 @@ succession_laws = {
 		
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {
@@ -229,7 +229,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {
@@ -324,7 +324,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					NOT = { has_law = revokation_2 }
@@ -404,7 +404,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					holder_scope = {
@@ -485,7 +485,7 @@ succession_laws = {
 		}
 		allow = {
 			OR = {
-				is_ruler = no # Black magic fix until vanilla gets its act together
+				hidden_tooltip = { is_ruler = no } # Black magic fix until vanilla gets its act together
 				is_recent_grant = yes
 				AND = {
 					OR = {


### PR DESCRIPTION
Again, for reference: `has_law = succ_gavelkind` as a condition does NOT fix the opinion modifiers, while `is_ruler = no` seems to do the job, and `has_crown_law_title = no` looks like it might also work but hasn't been tested as thoroughly.
