### PR TITLE
Decisions cleanup

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,7 @@
-﻿3.5.12
+﻿3.5.13
+	No Ahistorical Empires scenario customization decision has been removed due to a vanilla bug to avoid confusion; manually invoking meneth.512 still works
+
+3.5.12
 	It is no longer possible to press a third-party's claim on a holy order (vanilla succession bug generates random HO claims when it should generate none)
 	Succession law opinions should now be properly applied to a ruler's family (this issue was also caused by a vanilla bug)
 	Gender Equality module now properly removes crippling negative opinions (this issue was caused by a vanilla bug)

--- a/ProjectBalance/decisions/00_PB_customization.txt
+++ b/ProjectBalance/decisions/00_PB_customization.txt
@@ -19,25 +19,26 @@ decisions = {
 		}
 	}
 	#No Ahistorical Empires
-	no_ahistorical_empires = {
-		potential = {
-			NOT = { had_global_flag = { flag = project_balance days = 1 } } #Only on day 0
-			ai = no
-			NOT = { has_global_flag = no_ahistorical_empires }
-		}
-		effect = {
-			custom_tooltip = {
-				text = no_ahistorical_empires
-			}
-			hidden_tooltip = {
-				set_global_flag = no_ahistorical_empires
-				random_realm_character = {
-					limit = { is_landed = no }
-					narrative_event = { id = meneth.512 }
-				}
-			}
-		}
-	}
+	# Commented-out due to vanilla de_jure_liege effect being broken for now
+	# no_ahistorical_empires = {
+		# potential = {
+			# NOT = { had_global_flag = { flag = project_balance days = 1 } } #Only on day 0
+			# ai = no
+			# NOT = { has_global_flag = no_ahistorical_empires }
+		# }
+		# effect = {
+			# custom_tooltip = {
+				# text = no_ahistorical_empires
+			# }
+			# hidden_tooltip = {
+				# set_global_flag = no_ahistorical_empires
+				# random_realm_character = {
+					# limit = { is_landed = no }
+					# narrative_event = { id = meneth.512 }
+				# }
+			# }
+		# }
+	# }
 	#Gender Equality
 	gender_equality = {
 		potential = {

--- a/ProjectBalance/decisions/unit_decisions.txt
+++ b/ProjectBalance/decisions/unit_decisions.txt
@@ -1,0 +1,47 @@
+decisions = {
+
+	conscript_merchant_ships = {
+		is_high_prio = yes
+		potential = {
+			NOT = {
+				has_earmarked_regiments = conscripted_merchant_ships
+			}
+			has_overseas_holdings = yes
+		}
+		allow = {
+			war = yes
+			wealth = 50
+		}
+		effect = {
+			wealth = -50
+			spawn_fleet = {
+				province = closest # closest sea zone
+				owner = ROOT
+				disband_on_peace = yes
+				earmark = conscripted_merchant_ships
+				troops =
+				{
+					galleys = { 20 20 }
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				year = 1100
+			}
+			modifier = {
+				factor = 0
+				NOT = {
+					any_war = {
+						OR = {
+							defender = { character = ROOT }
+							attacker = { character = ROOT }
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/ProjectBalance/decisions/unit_decisions.txt
+++ b/ProjectBalance/decisions/unit_decisions.txt
@@ -3,6 +3,7 @@ decisions = {
 	conscript_merchant_ships = {
 		is_high_prio = yes
 		potential = {
+			had_global_flag = { flag = project_balance days = 1 }
 			NOT = {
 				has_earmarked_regiments = conscripted_merchant_ships
 			}


### PR DESCRIPTION
- NAE has finally been disabled until Paradox works its "issues" out
- Conscript Merchant Ships decision, like many other over-prioritised `is_high_prio = yes` decisions, no longer forces itself to the top on D-Day, obscuring scenario customization decisions
