### PR TITLE
Mending schism requires only 75% religious authority

### DIFF
--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,7 @@
-﻿3.5.14
+﻿3.5.15
+	FIX: Mending the Great Schism (Orthodox or Catholic) now requires only 75% religious authority (consistent with nerf to controlled-holy-sites bonus)
+
+3.5.14
 	Fixed the Imperial Reconquest war checks being impossible to toggle
 	Tribal Invasion CB usage by non-Hordes limited to one usage per lifetime; Pagan Subjugation CB tied to same lifetime block (one or the other)
 	FIX: Mongol generals won't spawn for the Khagan holding a Nerge unless he too is of Mongol culture

--- a/ProjectBalance/decisions/CatholicSchism.txt
+++ b/ProjectBalance/decisions/CatholicSchism.txt
@@ -14,7 +14,7 @@ decisions = {
 			NOT = { has_global_flag = schism_mended }
 		}
 		allow = {
-			religion_authority = 0.9
+			religion_authority = 0.75 #Consistent with nerf to controlled holy sites bonus to religious authority
 			OR = {
 				AND = {
 					completely_controls = c_byzantion

--- a/ProjectBalance/decisions/realm_decisions.txt
+++ b/ProjectBalance/decisions/realm_decisions.txt
@@ -371,7 +371,7 @@ decisions = {
 		}
 		allow = {
 			piety = 2000
-			religion_authority = 0.9
+			religion_authority = 0.75 #Consistent with nerf to controlled holy sites bonus to religious authority
 			completely_controls = c_byzantion
 			b_hagiasophia = {
 				holder_scope = {


### PR DESCRIPTION
Consistent with nerf to controlled-holy-sites bonus to religious authority.
