### PR TITLE
Fixed empty war check menu for non-Byzantines

### DIFF
--- a/PB + SWMH/decisions/PB_war_checks_IR.txt
+++ b/PB + SWMH/decisions/PB_war_checks_IR.txt
@@ -4,6 +4,11 @@ decisions = {
 		potential = {
 			ai = no
 			NOT = { has_character_flag = holy_war_check }
+			OR = {
+				has_landed_title = e_byzantium
+				has_landed_title = e_roman_empire
+			}
+			religion_group = christian
 		}
 		effect = {
 			hidden_tooltip = {

--- a/ProjectBalance/PB ChangeLog.txt
+++ b/ProjectBalance/PB ChangeLog.txt
@@ -1,4 +1,5 @@
 ﻿3.5.15
+	FIX: "Is War Possible?" menu is now only available for Byzantines, because the answer is now, "Yes," to everyone else (no empty menu for non-Byzantines)
 	FIX: Mending the Great Schism (Orthodox or Catholic) now requires only 75% religious authority (consistent with nerf to controlled-holy-sites bonus)
 
 3.5.14

--- a/ProjectBalance/decisions/PB_war_checks_IR.txt
+++ b/ProjectBalance/decisions/PB_war_checks_IR.txt
@@ -4,6 +4,11 @@ decisions = {
 		potential = {
 			ai = no
 			NOT = { has_character_flag = holy_war_check }
+			OR = {
+				has_landed_title = e_byzantium
+				has_landed_title = e_roman_empire
+			}
+			religion_group = christian
 		}
 		effect = {
 			hidden_tooltip = {


### PR DESCRIPTION
"Is War Possible?" menu is now only available for Byzantines, because the answer is now simply, "Yes," to everyone else.
